### PR TITLE
[FSDE-12497] Refactored Data Table Bulk Actions

### DIFF
--- a/src/chi-vue/src/components/data-table-bulk-actions/DataTableBulkActions.tsx
+++ b/src/chi-vue/src/components/data-table-bulk-actions/DataTableBulkActions.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { findComponent } from '@/utils/utils';
 import {
   BULK_ACTIONS_CLASSES,
@@ -11,33 +11,38 @@ import {
 } from '@/constants/classes';
 import DataTable from '../data-table/DataTable';
 import { ICON_CLASSES } from '@/constants/icons';
-
-let dataTableNumber = 0;
+import { DATA_TABLE_EVENTS } from '@/constants/events';
 
 @Component({})
 export default class DataTableBulkActions extends Vue {
-  @Prop() selectedRows!: number;
+  @Prop({ required: true }) selectedRows!: number;
+  @Prop({ required: true }) uuid!: number | string;
 
-  showBulkActions?: boolean = true;
-  showTopBottomNavOnMobileView?: boolean = true;
+  isBulkActionsVisible = this._checkBulkActionVisibility();
 
   _emitSelectedRows(e: any) {
-    this.$emit('chiShowSelectedRowsOnly', e.srcElement.checked);
+    this.$emit(DATA_TABLE_EVENTS.BULK_ACTIONS.SHOW_SELECTED_ONLY, e.srcElement.checked);
   }
 
   _emitSelectedAll(e: Event) {
-    e.preventDefault();
-    this.$emit('chiMobileSelectedAll', e);
+    this.$emit(DATA_TABLE_EVENTS.SELECTED_ALL, e);
   }
 
-  _emitCancel(e: Event) {
-    e.preventDefault();
-    this.showTopBottomNavOnMobileView = false;
-    this.$emit('chiMobileCancel', e);
+  _cancel() {
+    this.isBulkActionsVisible = false;
+  }
+
+  _checkBulkActionVisibility() {
+    return this.$props.selectedRows > 0;
+  }
+
+  @Watch('selectedRows')
+  visibilityChange() {
+    this.isBulkActionsVisible = this._checkBulkActionVisibility();
   }
 
   created() {
-    dataTableNumber += 1;
+    this.visibilityChange();
   }
 
   mounted() {
@@ -48,65 +53,63 @@ export default class DataTableBulkActions extends Vue {
     }
   }
 
-  toggleBulkActions() {
-    this.$props.selectedRows = 0;
-  }
-
   render() {
     const startSlot = this.$scopedSlots['start'] ? this.$scopedSlots['start']({}) : null;
 
     return (
       <transition name="slide-fade">
-        {this.$props.selectedRows > 0 && (
+        {this.isBulkActionsVisible && (
           <div class={`${BULK_ACTIONS_CLASSES.BULK_ACTIONS}`}>
-            {this.showTopBottomNavOnMobileView && (
-              <div class={`${BULK_ACTIONS_CLASSES.BULK_ACTIONS_TOP} ${UTILITY_CLASSES.Z_INDEX.Z_40}`}>
-                <chi-link
-                  href="#"
-                  onClick={(e: Event) => {
-                    this._emitSelectedAll(e);
-                  }}>
-                  Select all
-                </chi-link>
-                <chi-link
-                  href="#"
-                  onClick={(e: Event) => {
-                    this._emitCancel(e);
-                  }}>
-                  Cancel
-                </chi-link>
-              </div>
-            )}
-            <div class={`${BULK_ACTIONS_CLASSES.BULK_ACTIONS_START}`}>
+            <div class={`${BULK_ACTIONS_CLASSES.BULK_ACTIONS_TOP} ${UTILITY_CLASSES.Z_INDEX.Z_10}`}>
+              <button
+                class={`${BUTTON_CLASSES.BUTTON} ${BUTTON_CLASSES.FLAT} ${UTILITY_CLASSES.PADDING.X[1]}`}
+                onClick={(e: Event) => {
+                  e.preventDefault();
+                  this._emitSelectedAll(e);
+                }}>
+                Select all
+              </button>
+              <button
+                class={`${BUTTON_CLASSES.BUTTON} ${BUTTON_CLASSES.FLAT} ${UTILITY_CLASSES.PADDING.X[1]}`}
+                onClick={() => {
+                  this._cancel();
+                  this.$emit(DATA_TABLE_EVENTS.BULK_ACTIONS.CANCEL);
+                }}>
+                Cancel
+              </button>
+            </div>
+            <div class={`${BULK_ACTIONS_CLASSES.BULK_ACTIONS_START} ${UTILITY_CLASSES.Z_INDEX.Z_10}`}>
               <div class={`${BULK_ACTIONS_CLASSES.BULK_ACTIONS_RESULTS}`}>
-                <div class={`${BULK_ACTIONS_CLASSES.BULK_ACTIONS_LABELS}`}>Actions ({this.selectedRows} Selected)</div>
+                <div class={`${BULK_ACTIONS_CLASSES.BULK_ACTIONS_LABEL}`}>Actions ({this.selectedRows} Selected)</div>
                 <div class={`${FORM_CLASSES.FORM_ITEM}`}>
                   <div class={`${CHECKBOX_CLASSES.checkbox}`}>
                     <input
-                      id={`checkbox-ba${dataTableNumber}-${this.selectedRows}`}
+                      id={`checkbox-ba-${this.uuid}-${this.selectedRows}`}
                       class={`${CHECKBOX_CLASSES.INPUT}`}
                       type="checkbox"
                       onClick={(e: Event) => {
                         this._emitSelectedRows(e);
                       }}
                     />
-                    <label
-                      class={`${CHECKBOX_CLASSES.LABEL}`}
-                      for={`checkbox-ba${dataTableNumber}-${this.selectedRows}`}>
+                    <label class={`${CHECKBOX_CLASSES.LABEL}`} for={`checkbox-ba-${this.uuid}-${this.selectedRows}`}>
                       Show Selected Only
                     </label>
                   </div>
                 </div>
               </div>
+              <div class="chi-divider -vertical"></div>
               {startSlot}
             </div>
             <div class={`${BULK_ACTIONS_CLASSES.BULK_ACTIONS_END}`}>
               <button
-                aria-label="Close"
+                aria-label="Close bulk actions"
                 class={`${BUTTON_CLASSES.BUTTON} ${BUTTON_CLASSES.ICON_BUTTON} ${CLOSE_CLASS}`}
-                onClick={() => this.toggleBulkActions()}>
+                onClick={() => {
+                  this.isBulkActionsVisible = false;
+                  this.$emit(DATA_TABLE_EVENTS.BULK_ACTIONS.CANCEL);
+                }}>
                 <div class={`${BUTTON_CLASSES.CONTENT} ${BUTTON_CLASSES.ICON_BUTTON} ${CLOSE_CLASS}`}>
-                  <i class={`${ICON_CLASS} ${ICON_CLASSES.ICON_X}`}></i>
+                  <i aria-hidden="true" class={`${ICON_CLASS} ${ICON_CLASSES.ICON_X}`}></i>
                 </div>
               </button>
             </div>

--- a/src/chi-vue/src/components/data-table/DataTable.tsx
+++ b/src/chi-vue/src/components/data-table/DataTable.tsx
@@ -1288,14 +1288,14 @@ export default class DataTable extends Vue {
     const classes = this._dataTableClasses(this.config.style, this._sortable),
       head = this._head(),
       toolbar = this._toolbar(),
-      bulkactions = this._bulkActions(),
+      bulkActions = this._bulkActions(),
       body = this._body(),
       pagination = this._pagination();
 
     return (
       <div class={classes} role="table" ref="dataTable" data-table-number={dataTableNumber}>
         {toolbar}
-        {bulkactions}
+        {bulkActions}
         {head}
         {body}
         {pagination}

--- a/src/chi-vue/src/components/data-table/constants/constants.ts
+++ b/src/chi-vue/src/components/data-table/constants/constants.ts
@@ -1,0 +1,23 @@
+import { UTILITY_CLASSES } from '@/constants/classes';
+import { DataTableExpansionIcons } from '@/constants/types';
+
+export const expansionIcons: DataTableExpansionIcons = {
+  portal: {
+    expanded: 'minus',
+    collapsed: 'plus',
+  },
+  base: {
+    expanded: 'chevron-up',
+    collapsed: 'chevron-right',
+  },
+};
+
+export const alignmentUtilityClasses: {
+  left: string;
+  center: string;
+  right: string;
+} = {
+  left: UTILITY_CLASSES.JUSTIFY.MD_START,
+  center: UTILITY_CLASSES.JUSTIFY.MD_CENTER,
+  right: UTILITY_CLASSES.JUSTIFY.MD_END,
+};

--- a/src/chi-vue/src/constants/classes.ts
+++ b/src/chi-vue/src/constants/classes.ts
@@ -10,9 +10,17 @@ export const ANIMATED_CLASS = '-animated';
 export const PORTAL_CLASS = '-portal';
 export const TRANSITIONING_CLASS = '-transitioning';
 export const SR_ONLY = '-sr--only';
+export const EXPAND_CLASS = '-expand';
 export const EXPANDED_CLASS = '-expanded';
 export const COLLAPSED_CLASS = '-collapsed';
 export const ONE_LINK_TX = 'OneLinkTx';
+export const GENERIC_SIZES = {
+  XS: '-xs',
+  SM: '-sm',
+  MD: '-md',
+  LG: '-lg',
+  XL: '-xl',
+};
 //#endregion
 
 //#region Accordion
@@ -30,7 +38,7 @@ export const BULK_ACTIONS_CLASSES = {
   BULK_ACTIONS_TOP: 'chi-bulk-actions__top',
   BULK_ACTIONS_START: 'chi-bulk-actions__start',
   BULK_ACTIONS_RESULTS: 'chi-bulk-actions__results',
-  BULK_ACTIONS_LABELS: 'chi-bulk-actions__label',
+  BULK_ACTIONS_LABEL: 'chi-bulk-actions__label',
   BULK_ACTIONS_END: 'chi-bulk-actions__end',
   BULK_ACTIONS_BUTTONS: 'chi-bulk-actions__buttons',
   BULK_ACTIONS_BUTTONS_MOBILE: 'chi-bulk-actions__buttons-mobile',
@@ -208,6 +216,8 @@ export const TOOLTIP_CLASSES = {
 //#region Utility Classes
 export const UTILITY_CLASSES = {
   Z_INDEX: {
+    Z_10: '-z--10',
+    Z_30: '-z--30',
     Z_40: '-z--40',
   },
   ALIGN_ITEMS: {

--- a/src/chi-vue/src/constants/events.ts
+++ b/src/chi-vue/src/constants/events.ts
@@ -3,7 +3,6 @@ import { DataTableRow } from './types';
 //#region Data Table
 export const DATA_TABLE_EVENTS = {
   SELECTED_ROWS_CHANGE: 'chiSelectedRowsChange',
-  SELECTED_ROWS_ONLY: 'chiShowSelectedRowsOnly',
   SELECTED_ROW: 'chiRowSelected',
   DESELECTED_ROW: 'chiRowDeselected',
   SELECTED_ALL: 'chiSelectAll',
@@ -14,7 +13,6 @@ export const DATA_TABLE_EVENTS = {
   COLUMNS_RESET: 'chiColumnsReset',
   ADVANCED_FILTERS_CHANGE: 'chiAdvancedFiltersChange',
   VIEWS_CHANGE: 'chiViewsChange',
-  MOBILE_CANCEL: 'chiMobileCancel',
   TOOLBAR: {
     COLUMNS_CHANGE: 'chiToolbarColumnsChange',
     COLUMNS_RESET: 'chiToolbarColumnsReset',
@@ -22,6 +20,10 @@ export const DATA_TABLE_EVENTS = {
     FILTERS_CHANGE: 'chiToolbarFiltersChange',
     SEARCH: 'chiToolbarSearch',
     VIEWS_CHANGE: 'chiToolbarViewsChange',
+  },
+  BULK_ACTIONS: {
+    CANCEL: 'chiCancel',
+    SHOW_SELECTED_ONLY: 'chiShowSelectedRowsOnly',
   },
   EXPANSION: {
     EXPANDED: 'chiRowExpanded',

--- a/src/chi-vue/src/constants/types.ts
+++ b/src/chi-vue/src/constants/types.ts
@@ -41,6 +41,7 @@ export interface DataTableRow {
   active: boolean;
   expanded: boolean;
   data: Record<string, any>;
+  level: number;
   nestedContent: DataTableRowNestedContent;
   id: string;
   rowId: string;

--- a/src/chi-vue/src/views/DataTable/ClientSide/DataTableClientView.vue
+++ b/src/chi-vue/src/views/DataTable/ClientSide/DataTableClientView.vue
@@ -12,7 +12,6 @@
       @chiRowCollapsed="e => this.rowCollapsed(e)"
       @chiRowSelected="e => this.rowSelected(e)"
       @chiRowDeselected="e => this.rowDeselected(e)"
-      @chiMobileCancel="e => this.chiMobileCancel(e)"
     >
       <template #alertsDesc="payload">
         <i :class="`chi-icon icon-${payload.success.icon} -icon--${payload.success.color}`" aria-hidden="true"></i>
@@ -106,10 +105,8 @@
         </ChiDataTableToolbar>
       </template>
       <template #bulkActions>
-        <div class="chi-bulk-actions__buttons -pl--3">
-          <div
-            :class="`${showBottomNavOnMobileView === false ? '-d--none' : 'chi-bulk-actions__buttons-mobile -z--40'}`"
-          >
+        <div class="chi-bulk-actions__buttons">
+          <div class="chi-bulk-actions__buttons-mobile -z--40">
             <chi-button variant="flat" type="icon" aria-label="Edit">
               <chi-icon icon="edit"></chi-icon>
             </chi-button>
@@ -169,8 +166,6 @@ import ColumnCustomization from '../../../components/column-customization/Column
 import { exampleConfig, exampleToolbar, exampleTableHead, exampleTableBody } from './fixtures';
 import DataTableViews from '../../../components/data-table-views/DataTableViews';
 
-const MOCK_API_RESPONSE_DELAY = 5000;
-
 @Component({
   components: {
     ChiDataTable: DataTable,
@@ -199,12 +194,12 @@ const MOCK_API_RESPONSE_DELAY = 5000;
     chiShowSelectedRowsOnly: e => {
       console.log('chiColumnsReset', e);
     },
-    chiMobileSelectedAll: e => {
-      console.log('chiMobileSelectedAll', e);
+    chiSelectAll: e => {
+      console.log('chiSelectAll', e);
     },
-    chiMobileCancel(e) {
+    chiCancel(e) {
       this.$data.showBottomNavOnMobileView = false;
-      console.log('chiMobileCancel', e);
+      console.log('chiCancel', e);
     },
     pageChange: e => {
       console.log('chiPageChange', e);
@@ -255,15 +250,15 @@ const MOCK_API_RESPONSE_DELAY = 5000;
         body: exampleTableBody,
       },
       months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-      showBottomNavOnMobileView: true,
     };
   },
 })
 export default class DataTableView extends Vue {
   mounted() {
-    setTimeout(() => {
-      // This example is present to demonstrate asynchronous updating of the data
+    // This example is present to demonstrate asynchronous updating of the data
+    const MOCK_API_RESPONSE_DELAY = 5000;
 
+    setTimeout(() => {
       const newData = [
         { template: 'ticketId', payload: { id: 'NTM000021063' } },
         {
@@ -271,7 +266,7 @@ export default class DataTableView extends Vue {
           payload: { icon: 'circle-check', color: 'success' },
         },
         { template: 'status', payload: { status: 'active' } },
-        'Colocation',
+        'Colocation A',
         0,
         { template: 'date', payload: { date: new Date('04/05/2018 8:00 AM') } },
         'SVUJW034781A',

--- a/src/chi-vue/src/views/DataTable/ServerSide/DataTableServerView.vue
+++ b/src/chi-vue/src/views/DataTable/ServerSide/DataTableServerView.vue
@@ -41,6 +41,44 @@
       <template #date="payload">
         {{ `${payload.date.getDate()} ${months[payload.date.getMonth()]} ${payload.date.getFullYear()}` }}
       </template>
+      <template #bulkActions>
+        <ChiDataTableBulkActions uuid="example-server-side-uuid" :selectedRows="selectedFirstLevelRows.length">
+          <div class="chi-bulk-actions__buttons" slot="start">
+            <div class="chi-bulk-actions__buttons-mobile -z--40">
+              <chi-button variant="flat" type="icon" aria-label="Edit">
+                <chi-icon icon="edit"></chi-icon>
+              </chi-button>
+              <chi-button variant="flat" type="icon" aria-label="Compose">
+                <chi-icon icon="compose"></chi-icon>
+              </chi-button>
+              <chi-button variant="flat" type="icon" aria-label="Delete">
+                <chi-icon icon="delete"></chi-icon>
+              </chi-button>
+              <chi-button variant="flat" type="icon" aria-label="Print">
+                <chi-icon icon="print"></chi-icon>
+              </chi-button>
+            </div>
+            <div class="chi-bulk-actions__buttons-desktop">
+              <chi-button size="xs" aria-label="Download">
+                <chi-icon icon="arrow-to-bottom"></chi-icon>
+                <span> Download </span>
+              </chi-button>
+              <chi-button size="xs" aria-label="Compose">
+                <chi-icon icon="arrow-to-bottom"></chi-icon>
+                <span> Compose </span>
+              </chi-button>
+              <chi-button size="xs" aria-label="Delete">
+                <chi-icon icon="arrow-to-bottom"></chi-icon>
+                <span> Delete </span>
+              </chi-button>
+              <chi-button size="xs" aria-label="Print">
+                <chi-icon icon="arrow-to-bottom"></chi-icon>
+                <span> Print </span>
+              </chi-button>
+            </div>
+          </div>
+        </ChiDataTableBulkActions>
+      </template>
       <template #loadingSkeleton>
         <div class="-d--flex -flex--column -w--100">
           <div class="chi-skeleton -w--85 -w-md--75 -w-lg--50"></div>
@@ -59,6 +97,7 @@ import DataTable from '../../../components/data-table/DataTable';
 import Actions from '../DataTableTemplates/example-actions.vue';
 import TicketPopover from '../DataTableTemplates/example-popover.vue';
 import DataTableToolbar from '../../../components/data-table-toolbar/DataTableToolbar';
+import DataTableBulkActions from '../../../components/data-table-bulk-actions/DataTableBulkActions';
 import SearchInput from '../../../components/search-input/SearchInput';
 import DataTableFilters from '../../../components/data-table-filters/DataTableFilters';
 import ColumnCustomization from '../../../components/column-customization/ColumnCustomization';
@@ -70,6 +109,7 @@ import { DataTableRow } from '../../../constants/types';
   components: {
     ChiDataTable: DataTable,
     ChiDataTableToolbar: DataTableToolbar,
+    ChiDataTableBulkActions: DataTableBulkActions,
     ChiSearchInput: SearchInput,
     ChiDataTableFilters: DataTableFilters,
     ChiColumnCustomization: ColumnCustomization,
@@ -84,6 +124,7 @@ import { DataTableRow } from '../../../constants/types';
         body: exampleTablePage1,
       },
       months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+      selectedFirstLevelRows: [],
     };
   },
 })
@@ -93,10 +134,14 @@ export default class DataTableView extends Vue {
   }
 
   rowSelected(rowData: DataTableRow) {
+    this.$data.selectedFirstLevelRows.push(rowData);
     console.log('Row selected', rowData);
   }
 
   rowDeselected(rowData: DataTableRow) {
+    const indexOfRow = this.$data.selectedFirstLevelRows.findIndex((row: DataTableRow) => row.rowId === rowData.rowId);
+
+    this.$data.selectedFirstLevelRows.splice(indexOfRow, 1);
     console.log('Row deselected', rowData);
   }
 

--- a/src/website/views/components/toolbar/_examples.pug
+++ b/src/website/views/components/toolbar/_examples.pug
@@ -1236,44 +1236,6 @@ h2 Examples
             button.chi-button.-icon.-flat(aria-label="Button action")
               .chi-button__content
                 i.chi-icon.icon-x(aria-hidden="true")
-      .chi-bulk-actions
-        .chi-bulk-actions__top
-          chi-link(href='#') Select all
-          chi-link(href='#') Clear
-        .chi-bulk-actions__start
-          .chi-bulk-actions__results
-            .chi-bulk-actions__label Actions (10 Selected)
-            .chi-form__item
-              .chi-checkbox
-                input#checkbox-ba1.chi-checkbox__input(type='checkbox')
-                label.chi-checkbox__label(for='checkbox-ba1') Show Selected Only
-          .chi-bulk-actions__buttons
-            .chi-bulk-actions__buttons-mobile
-              chi-button(variant='flat' type='icon' alternative-text='Button action' data-tooltip='Edit')
-                chi-icon(icon='edit')
-              chi-button(variant='flat' type='icon' alternative-text='Button action' data-tooltip='Compose')
-                chi-icon(icon='compose')
-              chi-button(variant='flat' type='icon' alternative-text='Button action' data-tooltip='Delete')
-                chi-icon(icon='delete')
-              chi-button(variant='flat' type='icon' alternative-text='Button action' data-tooltip='Print')
-                chi-icon(icon='print')
-            .chi-bulk-actions__buttons-desktop
-              .chi-divider.-vertical
-              chi-button(size='xs')
-                chi-icon(icon='arrow-to-bottom')
-                span Download
-              chi-button(size='xs')
-                chi-icon(icon='compose')
-                span Compose
-              chi-button(size='xs')
-                chi-icon(icon='delete')
-                span Delete
-              chi-button(size='xs')
-                chi-icon(icon='print')
-                span Print
-        .chi-bulk-actions__end
-          chi-button(type='close')
-
     .example-tabs.-pl--2
       ul.chi-tabs#example-portal-ribbon(role="tablist")
         li.-disabled
@@ -1394,57 +1356,6 @@ h2 Examples
                 </div>
               </button>
             </div>
-          </div>
-        </div>
-        <div class="chi-bulk-actions">
-          <div class="chi-bulk-actions__top">
-            <chi-link href="#">Select all</chi-link>
-            <chi-link href="#">Clear</chi-link>
-          </div>
-          <div class="chi-bulk-actions__start">
-            <div class="chi-bulk-actions__results">
-              <div class="chi-bulk-actions__label">Actions (10 Selected)</div>
-              <div class="chi-form__item">
-                <div class="chi-checkbox">
-                  <input class="chi-checkbox__input" id="checkbox-ba1" type="checkbox" />
-                  <label class="chi-checkbox__label" for="checkbox-ba1">Show Selected Only</label>
-                </div>
-              </div>
-            </div>
-            <div class="chi-bulk-actions__buttons">
-              <div class="chi-bulk-actions__buttons-mobile">
-                <chi-button variant="flat" type="icon" alternative-text="Button action" data-tooltip="Edit">
-                  <chi-icon icon="edit"></chi-icon>
-                </chi-button>
-                <chi-button variant="flat" type="icon" alternative-text="Button action" data-tooltip="Compose">
-                  <chi-icon icon="compose"></chi-icon>
-                </chi-button>
-                <chi-button variant="flat" type="icon" alternative-text="Button action" data-tooltip="Delete">
-                  <chi-icon icon="delete"></chi-icon>
-                </chi-button>
-                <chi-button variant="flat" type="icon" alternative-text="Button action" data-tooltip="Print">
-                  <chi-icon icon="print"></chi-icon>
-                </chi-button>
-              </div>
-              <div class="chi-bulk-actions__buttons-desktop">
-                <div class="chi-divider -vertical"></div>
-                <chi-button size="xs">
-                  <chi-icon icon="arrow-to-bottom"></chi-icon><span>Download</span>
-                </chi-button>
-                <chi-button size="xs">
-                  <chi-icon icon="compose"></chi-icon><span>Compose</span>
-                </chi-button>
-                <chi-button size="xs">
-                  <chi-icon icon="delete"></chi-icon><span>Delete</span>
-                </chi-button>
-                <chi-button size="xs">
-                  <chi-icon icon="print"></chi-icon><span>Print</span>
-                </chi-button>
-              </div>
-            </div>
-          </div>
-          <div class="chi-bulk-actions__end">
-            <chi-button type="close"></chi-button>
           </div>
         </div>
 


### PR DESCRIPTION
### Commit summary

- [x] Addressed my comments on pr #241 
- [x] Fixed the additional issues I found:
        1. Sub-row selection - (Flow: Select a sub-row, select Show selected only, select another row. Does not filter the table to 1 row).
        2. `DataTable.tsx` `showSelectedOnly()` method inconsistent behavior. Needs to be rewritten.
        3. Select All inconsistent behavior with Bulk actions - Select `X` rows, select Show selected only, Deselect the SelectAll checkbox, only `X` rows are visible. The user is unable to see the other rows (initial state of Data Table).
        4. Select All not working on mobile.
        5. Visual issues on mobile - Layering - bottom gets covered with other elements, top bar height is inconsistent and links need to be changed by buttons.
        6. Fix Sorting Show Selected only mode
        7. Add support of Bulk Actions in Server Side mode
        8. Change Toolbar code snippets.

