### PR TITLE
[FSDE-30869] Fix: Remove modal prop from datatable head popover

### DIFF
--- a/src/chi-vue/src/components/data-table/DataTable.tsx
+++ b/src/chi-vue/src/components/data-table/DataTable.tsx
@@ -203,7 +203,6 @@ export default class DataTable extends Vue {
             reference={`#${infoPopoverId}`}
             position="top"
             title={(this.data.head[column].description as DataTableColumnDescription).title}
-            modal
             arrow>
             <div>{this._getDescription(this.data.head[column].description as string | DataTableColumnDescription)}</div>
           </chi-popover>


### PR DESCRIPTION
https://ctl.atlassian.net/browse/FSDE-30869

- Removed property `modal` from datatable popover component