### PR TITLE
[FSESF-647] Nested content shown always

### DIFF
--- a/src/chi-vue/src/constants/classes.ts
+++ b/src/chi-vue/src/constants/classes.ts
@@ -109,6 +109,7 @@ export const DATA_TABLE_CLASSES = {
   TRUNCATED: '-truncated',
   PRINT_FOOTER: 'chi-data-table__print-footer',
   STATE: '-state',
+  ALWAYS_OPENED: '-always-opened',
 };
 //#endregion
 

--- a/src/chi-vue/src/constants/types.ts
+++ b/src/chi-vue/src/constants/types.ts
@@ -32,6 +32,7 @@ export interface DataTableRowNestedContent {
   template: string;
   value: string;
   payload: any;
+  alwaysVisible?: boolean;
 }
 export interface DataTableRow {
   active: boolean;

--- a/src/chi-vue/src/views/DataTable/ClientSide/fixtures.ts
+++ b/src/chi-vue/src/views/DataTable/ClientSide/fixtures.ts
@@ -387,6 +387,7 @@ export const exampleTableBody = [
     active: false,
     nestedContent: {
       value: 'asdasdasd',
+      alwaysVisible: true,
     },
     data: [
       { template: 'ticketId', payload: { id: 'NTM000021064' } },

--- a/src/chi/components/data-table/data-table.scss
+++ b/src/chi/components/data-table/data-table.scss
@@ -19,6 +19,7 @@ $sizes: (
   )
 );
 
+
 .chi-data-table {
   border-collapse: collapse;
   display: block;
@@ -27,6 +28,18 @@ $sizes: (
   overflow-x: initial;
   overflow-y: initial;
   width: 100%;
+
+  .-always-opened {
+    box-shadow: none !important;
+  }
+  
+  .-striped-content{
+    background-color: #f5f8fc !important;
+  }
+  
+  .-white-content{
+    background-color: #ffffff !important;
+  }
 
   .chi-data-table__print-footer {
     padding: 1rem;


### PR DESCRIPTION
https://ctl.atlassian.net/browse/FSESF-647

Adding a property called `alwaysVisible` inside `nestedContent` object, allows a row to always display its nested content.