### PR TITLE
[DPEDE-1395] Add mutation observer to number input web component

### DIFF
--- a/src/custom-elements/src/components/number-input/number-input.tsx
+++ b/src/custom-elements/src/components/number-input/number-input.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, EventEmitter, Prop, State, Watch, h } from '@stencil/core';
 import { CallbackQueue } from '../../utils/CallbackQueue';
 import { CHI_STATES, ChiStates } from '../../constants/states';
+import { addMutationObserver } from '../../utils/mutationObserver';
 
 @Component({
   tag: 'chi-number-input',
@@ -124,6 +125,7 @@ export class NumberInput {
   _numberInput!: HTMLInputElement;
 
   connectedCallback() {
+    addMutationObserver.call(this);
     this.initialValue = this.value;
   }
 


### PR DESCRIPTION
[https://ctl.atlassian.net/browse/DPEDE-1395](https://ctl.atlassian.net/browse/DPEDE-1395)

This fix an error that occurs when "helperMessage" attribute is modified dynamically. After changing this attribute, up/down buttons don't work properly. Adding the mutation observer solves it because it forces to re-render children elements.

