### PR TITLE
[DPEDE-1413] Add mutation observer to app layout web component

### DIFF
--- a/src/custom-elements/src/components/app-layout/app-layout.tsx
+++ b/src/custom-elements/src/components/app-layout/app-layout.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Prop, Watch, h, State, Event, EventEmitter } from '@stencil/core';
 import { AppLayoutFormats, APP_LAYOUT_FORMATS } from '../../constants/constants';
+import { addMutationObserver } from '../../utils/mutationObserver';
 
 @Component({
   tag: 'chi-main',
@@ -54,8 +55,6 @@ export class AppLayout {
    */
   @Event({ eventName: 'chiBacklinkClick' }) eventBacklinkClick: EventEmitter;
 
-  private mutationObserver;
-
   @Watch('format')
   typeValidation(newValue: string) {
     if (newValue && !APP_LAYOUT_FORMATS.includes(newValue)) {
@@ -66,40 +65,24 @@ export class AppLayout {
   }
 
   connectedCallback() {
-    const observerTarget = this.el;
-    const mutationObserverConfig = {
-      attributes: true,
-      attributeOldValue: true,
-      attributeFilter: ['title'],
-    };
-
-    if (!this.mutationObserver) {
-      const subscriberCallback = (mutations) => {
-        mutations.forEach((mutation) => {
-          if (mutation.target.title) {
-            this.appLayoutTitle = mutation.target.title;
-            this.el.removeAttribute('title');
-          }
-        });
-      };
-
-      this.mutationObserver = new MutationObserver(subscriberCallback);
-    }
-
-    this.mutationObserver.observe(observerTarget, mutationObserverConfig);
+    addMutationObserver.call(this, () => {
+        if (this.el.title) {
+          this.appLayoutTitle = this.el.title;
+          this.el.removeAttribute('title');
+        }
+      },
+      { attributes: true, 
+        attributeOldValue: true, 
+        attributeFilter: ['title'], 
+        childList: true 
+      }
+    );
   }
 
-  disconnectedCallback() {
-    this.mutationObserver.disconnect();
-  }
+  disconnectedCallback() {}
 
   componentWillLoad() {
     this.typeValidation(this.format);
-
-    if (this.el.getAttribute('title')) {
-      this.appLayoutTitle = this.el.getAttribute('title');
-      this.el.removeAttribute('title');
-    }
 
     if (this.el.querySelector('[slot=help-icon]')) {
       this.appLayoutHelpIcon = true;

--- a/src/custom-elements/src/components/app-layout/app-layout.tsx
+++ b/src/custom-elements/src/components/app-layout/app-layout.tsx
@@ -65,21 +65,17 @@ export class AppLayout {
   }
 
   connectedCallback() {
-    addMutationObserver.call(this, () => {
+    addMutationObserver.call(
+      this,
+      () => {
         if (this.el.title) {
           this.appLayoutTitle = this.el.title;
           this.el.removeAttribute('title');
         }
       },
-      { attributes: true, 
-        attributeOldValue: true, 
-        attributeFilter: ['title'], 
-        childList: true 
-      }
+      { attributes: true, attributeOldValue: true, attributeFilter: ['title'], childList: true }
     );
   }
-
-  disconnectedCallback() {}
 
   componentWillLoad() {
     this.typeValidation(this.format);

--- a/src/custom-elements/src/components/popover/popover.tsx
+++ b/src/custom-elements/src/components/popover/popover.tsx
@@ -5,6 +5,7 @@ import { Drag } from '../../utils/Drag';
 import { ANIMATION_DURATION, CLASSES, ESCAPE_KEYCODE } from '../../constants/constants';
 import Popper, { Placement } from 'popper.js';
 import { POPOVER_CLASSES } from '../../constants/classes';
+import { addMutationObserver } from '../../utils/mutationObserver';
 
 @Component({
   tag: 'chi-popover',
@@ -93,7 +94,6 @@ export class Popover {
   private _closePreventedTimeout: number;
   private _documentClickHandler: () => void;
   private _documentKeyHandler: (event: KeyboardEvent) => void;
-  private mutationObserver;
   private _drag: Drag;
 
   @Watch('position')
@@ -335,24 +335,15 @@ export class Popover {
   }
 
   connectedCallback() {
-    const observerTarget = this.el;
-    const mutationObserverConfig = {
-      attributes: true,
-      attributeOldValue: true,
-      attributeFilter: ['title'],
-    };
-
-    if (!this.mutationObserver) {
-      const subscriberCallback = (mutations) => {
-        mutations.forEach((mutation) => {
-          this.popoverTitle = mutation.target.title;
-        });
-      };
-
-      this.mutationObserver = new MutationObserver(subscriberCallback);
-    }
-
-    this.mutationObserver.observe(observerTarget, mutationObserverConfig);
+    addMutationObserver.call(this, () => {
+        this.popoverTitle = this.el.title;
+      },
+      { attributes: true, 
+        attributeOldValue: true, 
+        attributeFilter: ['title'], 
+        childList: true 
+      }
+    );
   }
 
   componentWillLoad(): void {
@@ -404,7 +395,6 @@ export class Popover {
     this._componentLoaded = false;
     document.removeEventListener('click', this._documentClickHandler);
     document.removeEventListener('keyup', this._documentKeyHandler);
-    this.mutationObserver.disconnect();
   }
 
   componentDidUpdate(): void {

--- a/src/custom-elements/src/components/popover/popover.tsx
+++ b/src/custom-elements/src/components/popover/popover.tsx
@@ -5,7 +5,6 @@ import { Drag } from '../../utils/Drag';
 import { ANIMATION_DURATION, CLASSES, ESCAPE_KEYCODE } from '../../constants/constants';
 import Popper, { Placement } from 'popper.js';
 import { POPOVER_CLASSES } from '../../constants/classes';
-import { addMutationObserver } from '../../utils/mutationObserver';
 
 @Component({
   tag: 'chi-popover',
@@ -94,6 +93,7 @@ export class Popover {
   private _closePreventedTimeout: number;
   private _documentClickHandler: () => void;
   private _documentKeyHandler: (event: KeyboardEvent) => void;
+  private mutationObserver;
   private _drag: Drag;
 
   @Watch('position')
@@ -335,15 +335,24 @@ export class Popover {
   }
 
   connectedCallback() {
-    addMutationObserver.call(this, () => {
-        this.popoverTitle = this.el.title;
-      },
-      { attributes: true, 
-        attributeOldValue: true, 
-        attributeFilter: ['title'], 
-        childList: true 
-      }
-    );
+    const observerTarget = this.el;
+    const mutationObserverConfig = {
+      attributes: true,
+      attributeOldValue: true,
+      attributeFilter: ['title'],
+    };
+
+    if (!this.mutationObserver) {
+      const subscriberCallback = (mutations) => {
+        mutations.forEach((mutation) => {
+          this.popoverTitle = mutation.target.title;
+        });
+      };
+
+      this.mutationObserver = new MutationObserver(subscriberCallback);
+    }
+
+    this.mutationObserver.observe(observerTarget, mutationObserverConfig);
   }
 
   componentWillLoad(): void {
@@ -395,6 +404,7 @@ export class Popover {
     this._componentLoaded = false;
     document.removeEventListener('click', this._documentClickHandler);
     document.removeEventListener('keyup', this._documentKeyHandler);
+    this.mutationObserver.disconnect();
   }
 
   componentDidUpdate(): void {


### PR DESCRIPTION
[https://ctl.atlassian.net/browse/DPEDE-1413](https://ctl.atlassian.net/browse/DPEDE-1413)

Notes:

- Attribute "title" is removed from "chi-main" tag after the mutation, in order to remove html native tooltip in the whole component. (See FSDE-6040)
- I remove the part relative to "title" mutation from componentWillLoad hook because it is not necessary now. 

See old tickets for a better understanding:

[https://ctl.atlassian.net/browse/FSDE-31045](https://ctl.atlassian.net/browse/FSDE-31045)
[https://ctl.atlassian.net/browse/FSDE-6040](https://ctl.atlassian.net/browse/FSDE-6040)

