### PR TITLE
[DPEDE-1490] Review and fix DatePicker formats

### DIFF
--- a/src/custom-elements/src/components/date/date.tsx
+++ b/src/custom-elements/src/components/date/date.tsx
@@ -99,10 +99,11 @@ export class Date {
   }
 
   _handleNewDateValue(newValue: string) {
+    dayjs.extend(customParseFormat);
     if (this.multiple) {
       this._vm.dates = newValue.split(',').map((valueDay) => this.fromString(valueDay)) || [];
     } else {
-      const date = dayjs(newValue).format(this.format);
+      const date = dayjs(newValue, this.format).format(this.format);
 
       this._vm.dates = [this.fromString(date)];
     }


### PR DESCRIPTION
[https://ctl.atlassian.net/browse/DPEDE-1490](https://ctl.atlassian.net/browse/DPEDE-1490)

Bug: 

When format is "DD/MM/YYYY" and multiple is false, days and months switch each other (in the calendar but not in the input) after selecting one date.

Solution:

In handleNewDateValue function, I added customParseFormat extension from Day.js and change the way to format the date variable (see line 106).