### PR TITLE
[DPEDE-1541] POC add min width to resize handler

### DIFF
--- a/src/chi-vue/src/components/data-table/DataTable.tsx
+++ b/src/chi-vue/src/components/data-table/DataTable.tsx
@@ -297,7 +297,7 @@ export default class DataTable extends Vue {
       return <DataTableTooltip textWrap={this.cellWrap} msg={label} nIcons={nIcons} />;
     }
 
-    if (this.config.truncation) { 
+    if (this.config.truncation) {
       return <DataTableTooltip msg={label} header nIcons={nIcons} />;
     }
 

--- a/src/chi-vue/src/components/data-table/DataTable.tsx
+++ b/src/chi-vue/src/components/data-table/DataTable.tsx
@@ -284,7 +284,7 @@ export default class DataTable extends Vue {
     );
   }
 
-  _getHeadContent(label: string, icon?: string) {
+  _getHeadContent(label: string, icon?: string, nIcons?: number) {
     if (icon) {
       return (
         <Tooltip message={label}>
@@ -294,14 +294,14 @@ export default class DataTable extends Vue {
     }
 
     if (this.cellWrap) {
-      return <DataTableTooltip textWrap={this.cellWrap} msg={label} class="-w--100" />;
+      return <DataTableTooltip textWrap={this.cellWrap} msg={label} nIcons={nIcons} />;
     }
 
-    if (this.config.truncation) {
-      return <DataTableTooltip msg={label} header />;
+    if (this.config.truncation) { 
+      return <DataTableTooltip msg={label} header nIcons={nIcons} />;
     }
 
-    return label;
+    return <span>{label}</span>;
   }
 
   _head() {
@@ -365,7 +365,7 @@ export default class DataTable extends Vue {
         ) : null,
         sortBy = this.dataTableData.head[columnIndex].sortBy,
         sortable = this.dataTableData.head[columnIndex].sortable,
-        alignment = this._cellAlignment(this.dataTableData.head[columnIndex].align || 'left'),
+        alignment = this._cellAlignment(this.dataTableData.head[columnIndex].align ?? 'left'),
         sortIcon = sortable ? (
           <chi-button variant="flat" type="icon" alternative-text="Sort icon">
             <i
@@ -389,7 +389,8 @@ export default class DataTable extends Vue {
           this.config.columnSizes && this._currentScreenBreakpoint
             ? this.config.columnSizes[this._currentScreenBreakpoint][cellIndex]
             : null;
-
+      const nIcons = Number(!!sortIcon) + Number(!!infoIcon);
+      const headContent = this._getHeadContent(label as string, icon, nIcons);
       const sortableColumnHead = (
         <div
           aria-label={`Sort Column ${label}`}
@@ -411,7 +412,7 @@ export default class DataTable extends Vue {
               ${this.dataTableData.head[columnIndex].allowOverflow ? 'overflow: visible;' : ''}
               `}
         >
-          {this._getHeadContent(label as string, icon)}
+          {headContent}
           {infoIcon}
           {sortIcon}
         </div>
@@ -423,12 +424,13 @@ export default class DataTable extends Vue {
               ${alignment}
               ${cellWidth && cellWidth > 0 ? `-flex-basis--${cellWidth}` : ''}`}
           data-label={label}
+          data-column={columnName}
           style={`
               ${cellWidth === 0 ? 'display: none;' : ''}
               ${this.dataTableData.head[columnIndex].allowOverflow ? 'overflow: visible;' : ''}
           `}
         >
-          {this._getHeadContent(label as string, icon)}
+          {headContent}
           {infoIcon}
         </div>
       );

--- a/src/chi-vue/src/components/data-table/DataTableTooltip.tsx
+++ b/src/chi-vue/src/components/data-table/DataTableTooltip.tsx
@@ -9,6 +9,7 @@ export default class DataTableTooltip extends Vue {
   @Prop() msg!: string;
   @Prop() header?: boolean;
   @Prop() textWrap?: boolean;
+  @Prop() nIcons?: number;
 
   tooltip = false;
 
@@ -38,13 +39,15 @@ export default class DataTableTooltip extends Vue {
       </div>
     );
 
+    const margin = (this.nIcons ?? 0) * 25;
+
     return (
       <div
         onMouseenter={() => this.onShow()}
         onFocus={() => this.onShow()}
         onMouseleave={() => this.onHide()}
         onBlur={() => this.onHide()}
-        style={`max-width: fit-content; width: ${this.header ? 'calc(100% - 20px)' : '100%'};`}
+        style={`max-width: fit-content; width: calc(100% - ${margin}px);`}
       >
         {this.tooltip ? <Tooltip message={this.msg}>{content}</Tooltip> : content}
       </div>

--- a/src/chi-vue/src/views/DataTable/ClientSide/fixtures.ts
+++ b/src/chi-vue/src/views/DataTable/ClientSide/fixtures.ts
@@ -39,6 +39,7 @@ export const exampleConfig: DataTableConfig = {
     direction: 'descending',
   },
   truncation: true,
+  // cellWrap: true,
   treeSelection: true,
   print: {
     isNestedContentPrintDisabled: true,
@@ -309,6 +310,7 @@ export const exampleTableArrayHead = [
 
 export const exampleTableHead = {
   ticketId: {
+    // label: 'This is a long header content with a second line wrapping without tooltip: This is a long content for the tooltip in the wrapped cell',
     label: 'Ticket ID',
     sortable: true,
     sortBy: 'id',

--- a/src/chi-vue/src/views/DataTable/ClientSide/fixtures.ts
+++ b/src/chi-vue/src/views/DataTable/ClientSide/fixtures.ts
@@ -39,7 +39,6 @@ export const exampleConfig: DataTableConfig = {
     direction: 'descending',
   },
   truncation: true,
-  // cellWrap: true,
   treeSelection: true,
   print: {
     isNestedContentPrintDisabled: true,
@@ -310,7 +309,6 @@ export const exampleTableArrayHead = [
 
 export const exampleTableHead = {
   ticketId: {
-    // label: 'This is a long header content with a second line wrapping without tooltip: This is a long content for the tooltip in the wrapped cell',
     label: 'Ticket ID',
     sortable: true,
     sortBy: 'id',

--- a/src/chi/components/data-table/data-table.scss
+++ b/src/chi/components/data-table/data-table.scss
@@ -204,6 +204,7 @@ $sizes: (
     .-cell-wrap {
       display: -webkit-box;
       overflow: hidden;
+      overflow-wrap: break-word;
       white-space: normal;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 2;

--- a/src/website/views/components/data-table/examples/base/_complex.pug
+++ b/src/website/views/components/data-table/examples/base/_complex.pug
@@ -59,7 +59,7 @@ h3 Complex
             a(href='#vertical-base-2' role='tab' aria-selected='false' tabindex='-1' aria-controls='vertical-base-2') ExamplePopover.vue
         script.
           chi.tab(document.getElementById('example-vertical-base'));
-      .-flex--grow1
+      .-overflow--auto
         #vertical-base-1.chi-tabs-panel.-active(role='tabpanel')
           :code(lang='html')
             <!-- Vue component -->


### PR DESCRIPTION
https://ctl.atlassian.net/browse/DPEDE-1541

- Limits resiizing to 100px cell width in case that the table has cellWrap or truncation enabled
- Calculates needed space for contents in case that the table has neither cellWrap nor truncation enabled to avoid overflow
-  Removes space for text in DataTableTooltip to account for icons and avoid overflow