### PR TITLE
[DPEDE-1727] Fix missing link page in doc sidenav in vue docs

### DIFF
--- a/src/documentation/constants/constants.ts
+++ b/src/documentation/constants/constants.ts
@@ -185,6 +185,11 @@ export const NAVIGATION_COMPONENTS_ITEMS = [
     source: 'vue',
   },
   {
+    href: `components/link`,
+    label: 'Link',
+    source: 'pug',
+  },
+  {
     href: `components/marketing-icon`,
     label: 'Marketing icon',
     source: 'pug',


### PR DESCRIPTION
https://ctl.atlassian.net/browse/DPEDE-1727

To test --> link component in sidenav should appear for all parts of the documentation (both website and vue documentation)