### PR TITLE
[DPEDE-1729] Improve mutation observer in link component

### DIFF
--- a/src/custom-elements/src/components/link/link.tsx
+++ b/src/custom-elements/src/components/link/link.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Prop, State, Watch, h } from '@stencil/core';
+import { Component, Element, Prop, Watch, h } from '@stencil/core';
 import { addMutationObserver } from '../../utils/mutationObserver';
 
 @Component({
@@ -7,8 +7,6 @@ import { addMutationObserver } from '../../utils/mutationObserver';
   scoped: true,
 })
 export class Link {
-  @State() slotLinkContent = true;
-
   @Element() el: HTMLElement;
 
   /**
@@ -71,14 +69,15 @@ export class Link {
   }
 
   connectedCallback() {
-    addMutationObserver.call(this);
+    addMutationObserver.call(this, undefined, { childList: true, subtree: true });
   }
 
   componentWillLoad() {
     this.sizeValidation(this.size);
-    if (!this.el.querySelector('chi-icon')) {
-      this.slotLinkContent = false;
-    }
+  }
+
+  _hasIcon() {
+    return Boolean(this.el.querySelector('chi-icon'));
   }
 
   render() {
@@ -96,13 +95,9 @@ export class Link {
         download={this.download}
         {...(this.alternativeText && { 'aria-label': this.alternativeText })}
       >
-        {this.slotLinkContent ? (
-          <div class="chi-link__content">
-            <slot></slot>
-          </div>
-        ) : (
+        <div class={`${this._hasIcon() ? 'chi-link__content' : ''}`}>
           <slot></slot>
-        )}
+        </div>
       </a>
     );
   }


### PR DESCRIPTION
https://ctl.atlassian.net/browse/DPEDE-1729

Add subtree option to mutation observer and refactor render to have only one slot -- somehow having two slots in render had some strange behaviours