### PR TITLE
[DPEDE-1724] Create selectMode in dropdown

### DIFF
--- a/cypress/e2e/chi-custom-elements/dropdown.cy.js
+++ b/cypress/e2e/chi-custom-elements/dropdown.cy.js
@@ -1,52 +1,52 @@
 const positions = [
   {
     placement: 'top',
-    transform: 'translate3d(-21px, -80px, 0px)'
+    transform: 'translate3d(-21px, -80px, 0px)',
   },
   {
     placement: 'right',
-    transform: 'translate3d(86px, -20px, 0px)'
+    transform: 'translate3d(86px, -20px, 0px)',
   },
   {
     placement: 'bottom',
-    transform: 'translate3d(-7px, 40px, 0px)'
+    transform: 'translate3d(-7px, 40px, 0px)',
   },
   {
     placement: 'left',
-    transform: 'translate3d(-118px, -20px, 0px)'
+    transform: 'translate3d(-118px, -20px, 0px)',
   },
   {
     placement: 'top-start',
-    transform: 'translate3d(0px, -80px, 0px)'
+    transform: 'translate3d(0px, -80px, 0px)',
   },
   {
     placement: 'top-end',
-    transform: 'translate3d(-9px, -80px, 0px)'
+    transform: 'translate3d(-9px, -80px, 0px)',
   },
   {
     placement: 'right-start',
-    transform: 'translate3d(124px, 0px, 0px)'
+    transform: 'translate3d(124px, 0px, 0px)',
   },
   {
     placement: 'right-end',
-    transform: 'translate3d(118px, -40px, 0px)'
+    transform: 'translate3d(118px, -40px, 0px)',
   },
   {
     placement: 'bottom-start',
-    transform: 'translate3d(0px, 40px, 0px)'
+    transform: 'translate3d(0px, 40px, 0px)',
   },
   {
     placement: 'bottom-end',
-    transform: 'translate3d(0px, 40px, 0px)'
+    transform: 'translate3d(0px, 40px, 0px)',
   },
   {
     placement: 'left-start',
-    transform: 'translate3d(-117px, 0px, 0px)'
+    transform: 'translate3d(-117px, 0px, 0px)',
   },
   {
     placement: 'left-end',
-    transform: 'translate3d(-117px, -40px, 0px)'
-  }
+    transform: 'translate3d(-117px, -40px, 0px)',
+  },
 ];
 const DROPDOWN_DATA_CY = {
   BASE: '[data-cy="base-dropdown"]',
@@ -57,39 +57,43 @@ const DROPDOWN_DATA_CY = {
   DYNAMIC: '[data-cy="dynamic-dropdown"]',
   RETAIN_SELECTION: '[data-cy="retain-selection-dropdown"]',
   ICON: '[data-cy="icon-dropdown"]',
-  POSITION: positions.map(position => {
+  SELECT_MODE_SINGLE: '[data-cy="select-mode-single-dropdown"]',
+  SELECT_MODE_MULTI: '[data-cy="select-mode-multi-dropdown"]',
+  POSITION: positions.map((position) => {
     return {
       selector: `[data-cy="position-dropdown-${position.placement}"]`,
       placement: position.placement,
-      transform: position.transform
+      transform: position.transform,
     };
   }),
   METHOD: {
     TOGGLE: {
       DROPDOWN_TOGGLE: '[data-cy="method-dropdown-toggle"]',
-      TRIGGER: '#test-toggle-trigger'
+      TRIGGER: '#test-toggle-trigger',
     },
     SHOW: {
       DROPDOWN_SHOW: '[data-cy="method-dropdown-show"]',
-      TRIGGER: '#test-show-trigger'
+      TRIGGER: '#test-show-trigger',
     },
     HIDE: {
       DROPDOWN_HIDE: '[data-cy="method-dropdown-hide"]',
-      TRIGGER: '#test-hide-trigger'
-    }
+      TRIGGER: '#test-hide-trigger',
+    },
   },
   EVENT: {
     SHOW: '[data-cy="event-dropdown-show"]',
     HIDE: '[data-cy="event-dropdown-hide"]',
     KEYDOWN: '[data-cy="event-dropdown-keydown"]',
-    ITEM_SELECTED: '[data-cy="event-dropdown-item-selected"]'
-  }
+    ITEM_SELECTED: '[data-cy="event-dropdown-item-selected"]',
+  },
 };
 const DROPDOWN_TRIGGER = '.chi-button.chi-dropdown__trigger';
 const DROPDOWN_MENU = '.chi-dropdown__menu';
+const CHI_DROPDOWN = '.chi-dropdown';
 const DROPDOWN_ICON = 'chi-dropdown__icon';
 const DROPDOWN_MENU_ITEM = '.chi-dropdown__menu-item';
 const ACTIVE_CLASS = '-active';
+const TRUNCATE_TEXT_CLASS = '-text--truncate';
 
 const hasClassAssertion = (el, value) => {
   cy.get(el).should('have.class', value);
@@ -140,7 +144,7 @@ describe('Dropdown', () => {
       cy.get('@dropdownTrigger')
         .click()
         .wait(500)
-        .then($els => {
+        .then(($els) => {
           const win = $els[0].ownerDocument.defaultView;
           const after = win.getComputedStyle($els[0], ':after');
           const tr = after.transform;
@@ -171,7 +175,7 @@ describe('Dropdown', () => {
     });
 
     it('Should add -text--normal class on the button element', () => {
-      hasClassAssertion('@dropdownTrigger', '-text--normal')
+      hasClassAssertion('@dropdownTrigger', '-text--normal');
     });
   });
 
@@ -192,12 +196,9 @@ describe('Dropdown', () => {
     it('Should set max-height according to number of items given', () => {
       const maxHeight = 96;
 
-      cy.get('@dropdownMenu')
-        .should('not.be.visible');
-      cy.get('@dropdownTrigger')
-        .click();
-      cy.get('@dropdownMenu')
-        .should('be.visible')
+      cy.get('@dropdownMenu').should('not.be.visible');
+      cy.get('@dropdownTrigger').click();
+      cy.get('@dropdownMenu').should('be.visible');
       cy.get('@dropdownMenu')
         .invoke('height')
         .should('equal', maxHeight);
@@ -205,7 +206,7 @@ describe('Dropdown', () => {
   });
 
   describe('Position', () => {
-    DROPDOWN_DATA_CY.POSITION.forEach(position => {
+    DROPDOWN_DATA_CY.POSITION.forEach((position) => {
       it(`Should be placed to the position ${position.placement}`, () => {
         cy.get(position.selector).click();
         cy.get(position.selector)
@@ -213,6 +214,211 @@ describe('Dropdown', () => {
           .scrollIntoView({ offset: { top: -150, left: 0 } })
           .should('have.attr', 'style')
           .should('contain', `transform: ${position.transform}`);
+      });
+    });
+  });
+
+  describe('Select mode', () => {
+    describe('Single', () => {
+      beforeEach(() => {
+        cy.get(DROPDOWN_DATA_CY.SELECT_MODE_SINGLE).as('dropdown');
+        cy.get('@dropdown')
+          .find(DROPDOWN_TRIGGER)
+          .as('dropdownTrigger');
+        cy.get(DROPDOWN_DATA_CY.SELECT_MODE_SINGLE)
+          .find(DROPDOWN_MENU)
+          .as('dropdownMenu');
+      });
+
+      it('Should have "single" attribute and "-fluid" class', () => {
+        cy.get(DROPDOWN_DATA_CY.SELECT_MODE_SINGLE).should('have.attr', 'select-mode');
+        cy.get(DROPDOWN_DATA_CY.SELECT_MODE_SINGLE)
+          .find(CHI_DROPDOWN)
+          .should('have.class', '-fluid');
+      });
+
+      it('Should retain selection in only one item and emit only chiDropdownItemSelected event', () => {
+        const spyValueChanged = cy.spy();
+        const spyItemSelected = cy.spy();
+
+        cy.get('@dropdown').then((el) => {
+          el.on('chiDropdownValueChanged', spyValueChanged);
+          el.on('chiDropdownItemSelected', spyItemSelected);
+        });
+
+        cy.get('@dropdownTrigger').click();
+
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .first()
+          .click()
+          .should('have.class', ACTIVE_CLASS)
+          .then(() => {
+            expect(spyItemSelected).to.be.calledOnce;
+          });
+
+        cy.get('@dropdownTrigger').click();
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .eq(1)
+          .click()
+          .should('have.class', ACTIVE_CLASS)
+          .then(() => {
+            expect(spyItemSelected).to.be.calledTwice;
+          });
+
+        cy.get('@dropdownTrigger').click();
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .first()
+          .should('not.have.class', ACTIVE_CLASS)
+          .then(() => {
+            expect(spyValueChanged).to.not.be.called;
+          });
+
+        cy.get('@dropdownTrigger')
+          .invoke('text')
+          .should('equal', 'Menu item 2');
+      });
+    });
+
+    describe('Multi', () => {
+      beforeEach(() => {
+        cy.visit('tests/custom-elements/dropdown.html');
+        cy.get(DROPDOWN_DATA_CY.SELECT_MODE_MULTI).as('dropdown');
+        cy.get('@dropdown')
+          .find(DROPDOWN_TRIGGER)
+          .as('dropdownTrigger');
+        cy.get(DROPDOWN_DATA_CY.SELECT_MODE_MULTI)
+          .find(DROPDOWN_MENU)
+          .as('dropdownMenu');
+      });
+
+      it('Should have "single" attribute and "-fluid" class', () => {
+        cy.get(DROPDOWN_DATA_CY.SELECT_MODE_MULTI).should('have.attr', 'select-mode', 'multi');
+        cy.get(DROPDOWN_DATA_CY.SELECT_MODE_MULTI)
+          .find(CHI_DROPDOWN)
+          .should('have.class', '-fluid');
+      });
+
+      it('Should retain selection in more than one item and emit events with selected items', () => {
+        const spyValueChanged = cy.spy().as('spyValueChanged');
+        const spyItemSelected = cy.spy().as('spyItemSelected');
+
+        cy.get('@dropdown').then((el) => {
+          el.on('chiDropdownValueChanged', (ev) => spyValueChanged(ev.detail));
+          el.on('chiDropdownItemSelected', (ev) => spyItemSelected(ev.detail));
+        });
+
+        // select all items
+        cy.get('@dropdownTrigger').click();
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .each((item) => {
+            cy.wrap(item).click();
+            cy.get('@dropdownTrigger').click();
+          });
+
+        // all items should have active class
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .each((item) => {
+            cy.wrap(item).should('have.class', ACTIVE_CLASS);
+          });
+
+        // item selected event is emitted once per item
+        cy.get('@dropdownMenu').then(() => {
+          cy.get('@spyItemSelected')
+            .its('callCount')
+            .then((res) => expect(res).to.eq(6));
+        });
+        // value changed event emits all selected values
+        cy.get('@dropdownMenu').then(() => {
+          expect(
+            spyValueChanged
+              .getCall(5)
+              .calledWith(['Menu item 1', 'Menu item 2', 'Menu item 3', 'Menu item 4', 'Menu item 5', 'Menu item 6'])
+          ).to.eq(true);
+        });
+      });
+      it('Should emit event with only selected items', () => {
+        const spyValueChanged = cy.spy().as('spyValueChanged');
+        const spyItemSelected = cy.spy().as('spyItemSelected');
+
+        cy.get('@dropdown').then((el) => {
+          el.on('chiDropdownValueChanged', (ev) => spyValueChanged(ev.detail));
+          el.on('chiDropdownItemSelected', (ev) => spyItemSelected(ev.detail));
+        });
+
+        // select first and second items
+        cy.get('@dropdownTrigger').click();
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .first()
+          .click();
+       
+        cy.get('@dropdownTrigger').click();
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .eq(1).click();
+
+        // unselect first item
+        cy.get('@dropdownTrigger').click();
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .first()
+          .click();
+
+        // all items should have active class
+        cy.get('@dropdownTrigger').click();
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .first().should('not.have.class', ACTIVE_CLASS);
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .eq(1).should('have.class', ACTIVE_CLASS);
+        
+        // event itemSelected is emited only when item is selected, not unselected
+        cy.get('@dropdownMenu').then(() => {
+          cy.get('@spyItemSelected')
+            .its('callCount')
+            .then((res) => expect(res).to.eq(2));
+        });
+      });
+
+      it('Should show all values of selected items in button and truncate text', () => {
+        // select all items
+        cy.get('@dropdownTrigger').click();
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .each((item) => {
+            cy.wrap(item).click();
+            cy.get('@dropdownTrigger').click();
+          });
+
+          cy.get('@dropdownTrigger').invoke('text').should('equal', 'Menu item 1 ; Menu item 2 ; Menu item 3 ; Menu item 4 ; Menu item 5 ; Menu item 6');
+          cy.get('@dropdownTrigger').find('span').should('have.class', TRUNCATE_TEXT_CLASS);
+      });
+
+      it('Should show button text if all items are unselected', () => {
+        // select all items
+        cy.get('@dropdownTrigger').click();
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .each((item) => {
+            cy.wrap(item).click();
+            cy.get('@dropdownTrigger').click();
+          });
+          // unselect all items
+        cy.get('@dropdownMenu')
+          .find(DROPDOWN_MENU_ITEM)
+          .each((item) => {
+            cy.wrap(item).click();
+            cy.wrap(item).should('not.have.class', ACTIVE_CLASS)
+            cy.get('@dropdownTrigger').click();
+          });
+
+          cy.get('@dropdownTrigger').invoke('text').should('equal', '- Select -');
       });
     });
   });
@@ -232,14 +438,14 @@ describe('Dropdown', () => {
         cy.get(`@dropdown`)
           .then(function(dropdown) {
             dropdown[0].toggle();
-            return new Promise(resolve => resolve(dropdown));
+            return new Promise((resolve) => resolve(dropdown));
           })
           .find(DROPDOWN_MENU)
           .should('be.visible');
         cy.get(`@dropdown`)
           .then(function(dropdown) {
             dropdown[0].toggle();
-            return new Promise(resolve => resolve(dropdown));
+            return new Promise((resolve) => resolve(dropdown));
           })
           .find(DROPDOWN_MENU)
           .should('not.be.visible');
@@ -260,7 +466,7 @@ describe('Dropdown', () => {
         cy.get(`@dropdown`)
           .then(function(dropdown) {
             dropdown[0].show();
-            return new Promise(resolve => resolve(dropdown));
+            return new Promise((resolve) => resolve(dropdown));
           })
           .find(DROPDOWN_MENU)
           .should('be.visible');
@@ -281,7 +487,7 @@ describe('Dropdown', () => {
         cy.get(`@dropdown`)
           .then(function(dropdown) {
             dropdown[0].hide();
-            return new Promise(resolve => resolve(dropdown));
+            return new Promise((resolve) => resolve(dropdown));
           })
           .find(DROPDOWN_MENU)
           .should('not.be.visible');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ci": "gulp ci",
     "docker": "scripts/docker.sh",
     "start": "gulp watch",
+    "serve": "gulp serve",
     "start:customElements": "gulp custom-elements:watch",
     "test": "gulp test",
     "test-ce": "gulp test:custom-elements",

--- a/src/custom-elements/src/components/dropdown/dropdown.tsx
+++ b/src/custom-elements/src/components/dropdown/dropdown.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../constants/classes';
 import { CARDINAL_EXTENDED_POSITIONS } from '../../constants/positions';
 import { contains } from '../../utils/utils';
-import { FontWeight } from '../../constants/types';
+import { DROPDOWN_SELECT_MODES, DropdownSelectModes, FontWeight } from '../../constants/types';
 import { addMutationObserver } from '../../utils/mutationObserver';
 
 declare const chi: any;
@@ -32,7 +32,7 @@ export class Dropdown {
   /**
    * To render Dropdowns that span the full width of the parent container
    */
-  @Prop() fluid: boolean;
+  @Prop({ mutable: true }) fluid: boolean;
   /**
    * To configure activation on hover of the Dropdown with base-style button trigger
    */
@@ -102,7 +102,12 @@ export class Dropdown {
   /**
    * To retain the selection of the menu item and display it as the trigger
    */
-  @Prop() retainSelection?: boolean;
+  @Prop({ mutable: true }) retainSelection?: boolean;
+  /**
+   * To apply select-like functionality and styles
+   */
+  @Prop({ reflect: true, mutable: true }) selectMode?: DropdownSelectModes;
+
   /**
    * Triggered when hiding the Dropdown
    */
@@ -118,13 +123,17 @@ export class Dropdown {
   /**
    * Triggered when select an item in the dropdown menu
    */
-  @Event({ eventName: 'chiDropdownItemSelected' })
-  eventItemSelected: EventEmitter;
+  @Event({ eventName: 'chiDropdownItemSelected' }) eventItemSelected: EventEmitter;
+  /**
+   * Triggered when selected items have changed in the dropdown menu. Payload is an array
+   * of strings.
+   */
+  @Event({ eventName: 'chiDropdownValueChanged' }) eventValueChanged: EventEmitter;
 
   @State() _menuHeader: boolean;
   @State() _menuFooter: boolean;
   @State() _forceRender: boolean;
-  @State() _value: string;
+  @State() _value: string[] = [];
 
   @Element() el: HTMLElement;
 
@@ -135,7 +144,9 @@ export class Dropdown {
   private _dropdownMenuItemsWrapper: any;
   private _customTrigger: boolean;
   private _tooltip: any;
+  private _fluidClass: string;
 
+  //# region Lifecycle hooks
   connectedCallback() {
     const triggerSlotElement = this.el.querySelector('[slot="trigger"]');
 
@@ -165,13 +176,18 @@ export class Dropdown {
 
   componentWillLoad() {
     this._getDropdownMenuSlots();
+    this.validateSelectMode(this.selectMode);
+    this._setSelectModeProps();
+    this._updateFluidClass();
   }
 
   disconnectedCallback() {
     this._removeEventListeners();
     this._removeTooltip();
   }
+  //#endregion
 
+  //#region PropsWatchers and validations
   @Watch('position')
   positionValidation(newValue: string) {
     if (newValue && !CARDINAL_EXTENDED_POSITIONS.includes(newValue)) {
@@ -194,6 +210,34 @@ export class Dropdown {
       }
     }
   }
+
+  /**
+   * Validates select mode values and sets default value as single if property is used without value.
+   * E.g. <chi-dropdown select-mode> <--> <chi-dropdown select-mode="single">
+   */
+  validateSelectMode(selectMode) {
+    if (selectMode === '') {
+      this.selectMode = 'single';
+    } else if (selectMode && !DROPDOWN_SELECT_MODES.includes(selectMode)) {
+      throw new Error(
+        `${selectMode} is not a valid select mode for Dropdown. Valid values are ${DROPDOWN_SELECT_MODES.join(', ')}.`
+      );
+    }
+  }
+
+  @Watch('selectMode')
+  _setSelectModeProps() {
+    if (this.selectMode) {
+      this.retainSelection = true;
+      this.fluid = true;
+    }
+  }
+
+  @Watch('fluid')
+  _updateFluidClass() {
+    this._fluidClass = this.fluid ? FLUID_CLASS : '';
+  }
+  //#endregion
 
   @Method()
   async updatePopper() {
@@ -309,7 +353,7 @@ export class Dropdown {
     const menuItems = this._getDropdownMenuItems();
 
     menuItems.forEach((item: HTMLElement) => {
-      const isActive = item.textContent === this._value;
+      const isActive = this._value.includes(item.textContent);
 
       item.classList.toggle(ACTIVE_CLASS, isActive);
     });
@@ -317,7 +361,7 @@ export class Dropdown {
 
   setFixedWidth() {
     if (this.retainSelection && this._referenceElement) {
-      const button = this._referenceElement.getElementsByTagName('button')[0];
+      const button = this._getButtonElement();
 
       button.style.width = `${this._referenceElement.offsetWidth}px`;
       button.classList.add(UTILITY_CLASSES.DISPLAY.FLEX, UTILITY_CLASSES.JUSTIFY.BETWEEN);
@@ -349,26 +393,37 @@ export class Dropdown {
   };
 
   handlerSelectedMenuItem = (ev) => {
-    this.eventItemSelected.emit(ev.target.text);
+    this._updateValue(ev.target.text);
 
     if (this.retainSelection) {
-      this._value = ev.target.textContent;
       this.hide();
-      this.truncateButtonText();
       this.setActiveClassOnMenuItem();
+    } else {
+      
     }
   };
 
-  truncateButtonText() {
-    if (this.icon) return;
+  /**
+   * Either adds or removes a selected item from the value list.
+   * Multiple values are only allowed if selectMode is multi.
+   */
+  _updateValue(value: string) {
+    if (this.selectMode !== 'multi') {
+      this._value = [value];
+      this.eventItemSelected.emit(value);
+      return;
+    }
 
-    const button = this._referenceElement.getElementsByTagName('button')[0];
-    const span = document.createElement('span');
+    const valueIndex = this._value.indexOf(value);
 
-    button.textContent = '';
-    span.textContent = this._value;
-    span.classList.add(UTILITY_CLASSES.TYPOGRAPHY.TEXT_TRUNCATE);
-    button.appendChild(span);
+    if (valueIndex === -1) {
+      this._value = [...this._value, value];
+      this.eventItemSelected.emit(value);
+    } else {
+      this._value = this._value.filter((item) => item !== value);
+    }
+
+    this.eventValueChanged.emit(this._value);
   }
 
   handlerClickTrigger = () => {
@@ -450,6 +505,10 @@ export class Dropdown {
     return Array.from(children).filter((item: HTMLElement) => item.classList.contains(DROPDOWN_CLASSES.MENU_ITEM));
   }
 
+  _getButtonElement(): HTMLButtonElement {
+    return this._referenceElement.querySelector('button');
+  }
+
   _addEventListeners() {
     document.body.addEventListener('click', this.handlerClick.bind(this));
     document.body.addEventListener('keydown', this.handleKeyDown.bind(this));
@@ -480,17 +539,25 @@ export class Dropdown {
     });
   }
 
-  _setButtonContent() {
-    const icon = <chi-icon icon={this.icon}></chi-icon>;
-    const button = (this.retainSelection && this._value) ?? this.button;
+  _getButtonContent() {
+    let buttonContent = this.button;
 
-    return this.icon ? icon : button;
+    if (this.icon) {
+      buttonContent = <chi-icon icon={this.icon}></chi-icon>;
+    } else if (this.retainSelection && this._value.length) {
+      buttonContent = <span class={UTILITY_CLASSES.TYPOGRAPHY.TEXT_TRUNCATE}>{this._value.join(' ; ')}</span>;
+    }
+
+    return buttonContent;
   }
 
+  
+  /**
+   * Generates trigger button content, either default button text, selected value or icon
+   */
   renderTrigger() {
-    const buttonContent = this._setButtonContent();
+    const buttonContent = this._getButtonContent();
     const color = this.color ?? '';
-    const fluidClass = this.fluid ? FLUID_CLASS : '';
     const variant = this.variant ?? '';
     const size = this.size ?? '';
     const type = this.icon ? 'icon' : '';
@@ -502,7 +569,7 @@ export class Dropdown {
       <chi-button
         onChiClick={this.handlerClickTrigger}
         onChiMouseEnter={this.handlerMouseEnter}
-        class={fluidClass}
+        fluid={this.fluid}
         extra-class={this.getExtraClassForTriggerButton()}
         color={color}
         variant={variant}
@@ -525,7 +592,6 @@ export class Dropdown {
       ${DROPDOWN_CLASSES.TRIGGER}
       ${this.fontWeight ? `-text--${this.fontWeight}` : ''}
       ${this.active ? ACTIVE_CLASS : ''}
-      ${this.fluid ? FLUID_CLASS : ''}
       ${this.animateChevron ? ANIMATE_CLASS : ''}
       ${this.icon ? DROPDOWN_CLASSES.ICON : ''}
     `;
@@ -568,7 +634,7 @@ export class Dropdown {
           ${DROPDOWN_CLASSES.MENU}
           ${UTILITY_CLASSES.Z_INDEX.Z_10}
           ${this.active ? ACTIVE_CLASS : ''}
-          ${this.fluid ? FLUID_CLASS : ''}
+          ${this._fluidClass}
           ${this.description ? LIST_CLASS : ''}`}
         ref={(ref) => (this._dropdownMenuElement = ref)}
       >
@@ -585,7 +651,7 @@ export class Dropdown {
 
     return trigger ? (
       <div
-        class={`${DROPDOWN_CLASSES.DROPDOWN} ${this.active ? ACTIVE_CLASS : ''} ${this.fluid ? FLUID_CLASS : ''}`}
+        class={`${DROPDOWN_CLASSES.DROPDOWN} ${this.active ? ACTIVE_CLASS : ''} ${this._fluidClass}`}
         onMouseLeave={this.handlerMouseLeave}
       >
         {trigger}

--- a/src/custom-elements/src/components/dropdown/dropdown.tsx
+++ b/src/custom-elements/src/components/dropdown/dropdown.tsx
@@ -125,6 +125,10 @@ export class Dropdown {
    */
   @Event({ eventName: 'chiDropdownItemSelected' }) eventItemSelected: EventEmitter;
   /**
+   * Triggered when an item is deselected in the dropdown menu
+   */
+  @Event({ eventName: 'chiDropdownItemDeselected' }) eventItemDeselected: EventEmitter;
+  /**
    * Triggered when selected items have changed in the dropdown menu. Payload is an array
    * of strings.
    */
@@ -398,8 +402,6 @@ export class Dropdown {
     if (this.retainSelection) {
       this.hide();
       this.setActiveClassOnMenuItem();
-    } else {
-      
     }
   };
 
@@ -421,6 +423,7 @@ export class Dropdown {
       this.eventItemSelected.emit(value);
     } else {
       this._value = this._value.filter((item) => item !== value);
+      this.eventItemDeselected.emit(value);
     }
 
     this.eventValueChanged.emit(this._value);

--- a/src/custom-elements/src/components/label/label.tsx
+++ b/src/custom-elements/src/components/label/label.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Prop, h, Watch } from '@stencil/core';
 import { addMutationObserver } from '../../utils/mutationObserver';
+import { LABEL_SIZES, type LabelSizes } from '../../constants/size';
 
-const VALID_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'];
 
 @Component({
   tag: 'chi-label',
@@ -17,7 +17,7 @@ export class Label {
   /**
    * OPTIONAL. Size of the label. { xs, sm, md, lg, xl }.
    */
-  @Prop({ reflect: true }) size = 'md';
+  @Prop({ reflect: true }) size: LabelSizes = 'md';
   /**
    * To indicate which form field is required.
    */
@@ -28,8 +28,8 @@ export class Label {
   @Prop({ reflect: true }) optional = false;
 
   @Watch('size')
-  validateSizeAttribute(newValue: string) {
-    if (newValue && VALID_SIZES.indexOf(newValue) === -1) {
+  validateSizeAttribute(newValue: LabelSizes) {
+    if (newValue && LABEL_SIZES.indexOf(newValue) === -1) {
       throw new Error('Not valid size (' + newValue + '). Valid values are xs, sm, md, lg or xl. ');
     }
   }

--- a/src/custom-elements/src/constants/size.ts
+++ b/src/custom-elements/src/constants/size.ts
@@ -1,9 +1,11 @@
 export const ICON_SIZES = ['xs', 'sm', 'sm--2', 'sm--3', 'md', 'lg', 'xl', 'xxl'];
 export const MARKETING_ICON_SIZES = ['xs', 'sm', 'md', 'lg'];
 export const TEXT_INPUT_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export const LABEL_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
 export const TABS_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
 
 export type TextInputSizes = typeof TEXT_INPUT_SIZES[number];
 export type IconSizes = typeof ICON_SIZES[number];
 export type MarketingIconSizes = typeof MARKETING_ICON_SIZES[number];
 export type TabsSizes = typeof TABS_SIZES[number];
+export type LabelSizes = typeof LABEL_SIZES[number];

--- a/src/custom-elements/src/constants/types.ts
+++ b/src/custom-elements/src/constants/types.ts
@@ -36,6 +36,8 @@ export interface DropdownMenuItem {
   title: string;
   href: string;
 }
+export const DROPDOWN_SELECT_MODES = ['single', 'multi'] as const;
+export type DropdownSelectModes = typeof DROPDOWN_SELECT_MODES[number];
 
 export interface Time {
   hour: number;

--- a/src/custom-elements/src/index.html
+++ b/src/custom-elements/src/index.html
@@ -148,6 +148,13 @@
         <a class="chi-dropdown__menu-item" href="#" slot="menu">Item 3</a>
         <a class="chi-dropdown__menu-item" href="#" slot="menu">Item 4</a>
       </chi-dropdown>
+      <h3>Dropdown Select mode multi</h3>
+      <chi-dropdown button="Open drodopwn" select-mode="multi">
+        <a class="chi-dropdown__menu-item" href="#" slot="menu">Item 1</a>
+        <a class="chi-dropdown__menu-item" href="#" slot="menu">Item 2</a>
+        <a class="chi-dropdown__menu-item" href="#" slot="menu">Item 3</a>
+        <a class="chi-dropdown__menu-item" href="#" slot="menu">Item 4</a>
+      </chi-dropdown>
     </div>
     <div class="-p--3">
       <h3>Expansion panel</h3>

--- a/test/chi/custom-elements/dropdown.pug
+++ b/test/chi/custom-elements/dropdown.pug
@@ -171,6 +171,26 @@ chi-dropdown#dropdown-level-4(position="right-start" reference="#test-nesting-le
       a.chi-dropdown__menu-item(href='#' slot='menu') Menu item 2
       a.chi-dropdown__menu-item(href='#' slot='menu') Menu item 3
 
+.test-dropdown-select-mode-single.-mt--5(style='width: 500px; height: 200px;')
+  span.-text--h2=`Select mode single`
+  .chi-form__item
+    chi-dropdown(data-cy="select-mode-single-dropdown" select-mode button="- Select -")
+      a.chi-dropdown__menu-item(slot='menu') Menu item 1
+      a.chi-dropdown__menu-item(slot='menu') Menu item 2
+      a.chi-dropdown__menu-item(slot='menu') Menu item 3
+      a.chi-dropdown__menu-item(slot='menu') Menu item 4
+
+.test-dropdown-select-mode-multi.-mt--5(style='width: 500px; height: 200px;')
+  span.-text--h2=`Select mode multi`
+  .chi-form__item
+    chi-dropdown(data-cy="select-mode-multi-dropdown" select-mode="multi" button="- Select -")
+      a.chi-dropdown__menu-item(slot='menu') Menu item 1
+      a.chi-dropdown__menu-item(slot='menu') Menu item 2
+      a.chi-dropdown__menu-item(slot='menu') Menu item 3
+      a.chi-dropdown__menu-item(slot='menu') Menu item 4
+      a.chi-dropdown__menu-item(slot='menu') Menu item 5
+      a.chi-dropdown__menu-item(slot='menu') Menu item 6
+
 script.
   const multiLevelDropdowns = [
     {trigger: '#test-nesting-level-2', dropdown: '#dropdown-level-3'},


### PR DESCRIPTION
https://ctl.atlassian.net/browse/DPEDE-1724

- Documentation & visual tests will be implemented in another task. This is the first approach to the select-mode, styles and more functionality will be added later.

Adds `select-mode` property in dropdown:

- `select-mode` or `select-mode="single"` --> applies fluid & retain selection
- `select-mode="multi"` allows to select more than one item and selection will be retained. Event `chiDropdownValueChanged` is emitted with an array of the selected items. Clicking on a selected item will unselect it.

In `/tests/custom-elements/dropdown.html` there are examples of both select single and multi to test them.