### PR TITLE
[DPEDE-2106] Fix Code Scanning alerts for server.cjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "cypress": "^14.2.1",
         "dayjs": "^1.11.13",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.5.0",
         "normalize.css": "^8.0.1",
         "ora": "^8.2.0",
         "popper.js": "^1.16.1",
@@ -9701,6 +9702,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/fresh": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cypress": "^14.2.1",
     "dayjs": "^1.11.13",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.5.0",
     "normalize.css": "^8.0.1",
     "ora": "^8.2.0",
     "popper.js": "^1.16.1",

--- a/server.cjs
+++ b/server.cjs
@@ -1,27 +1,39 @@
 const express = require('express');
 const path = require('path');
 const fs = require('fs');
+const rateLimit = require('express-rate-limit');
 
 const app = express();
 const port = 8000;
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json')));
 const basePath = `/chi/${packageJson.version}`;
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100
+});
 
 app.use(basePath, express.static(path.join(__dirname, 'dist')));
+app.use(limiter);
 
 app.get(/(.*)/, (req, res) => {
   res.sendFile(path.join(__dirname, 'dist', 'index.html'));
 });
 
-
 app.get(new RegExp(`${basePath}/tests/(.*)`), (req, res) => {
   const requestedPath = req.path.replace(`${basePath}/tests`, '');
-  const testPath = path.join(__dirname, 'dist', 'tests', requestedPath);
+  const baseTestsPath = path.join(__dirname, 'dist', 'tests');
+  const testPath = path.resolve(baseTestsPath, requestedPath);
+
+   if (!testPath.startsWith(baseTestsPath)) {
+    res.status(403).send('Forbidden');
+    
+    return;
+  }
   
   if (fs.existsSync(testPath) && fs.lstatSync(testPath).isFile()) {
     res.sendFile(testPath);
   } else {
-    res.sendFile(path.join(__dirname, 'dist', 'tests', 'index.html'));
+    res.sendFile(path.join(baseTestsPath, 'index.html'));
   }
 });
 


### PR DESCRIPTION
Potential fix for: 

[https://github.com/CenturyLink/Chi/security/code-scanning/21](https://github.com/CenturyLink/Chi/security/code-scanning/21)
[https://github.com/CenturyLink/Chi/security/code-scanning/22](https://github.com/CenturyLink/Chi/security/code-scanning/22)
[https://github.com/CenturyLink/Chi/security/code-scanning/140](https://github.com/CenturyLink/Chi/security/code-scanning/140)
[https://github.com/CenturyLink/Chi/security/code-scanning/141](https://github.com/CenturyLink/Chi/security/code-scanning/141)

This pull request introduces rate-limiting to the server and improves security by preventing path traversal attacks. The most important changes include adding the `express-rate-limit` package, configuring a rate limiter, and enhancing path resolution logic in the `server.cjs` file.

### Security and rate-limiting improvements:

* **Added `express-rate-limit` package**: The `express-rate-limit` package was added to `package.json` to enable rate-limiting functionality. (`package.json`, [package.jsonR47](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R47))
* **Configured rate limiter**: A rate limiter was set up in `server.cjs` to restrict clients to a maximum of 100 requests per 15 minutes. The limiter was applied globally to all routes. (`server.cjs`, [server.cjsR4-R36](diffhunk://#diff-b5c2c6826250db328d90f6217a5c2cd8e9b55a94de682d42c4028a3075564c6eR4-R36))
* **Improved path resolution for security**: Updated the test file path resolution logic to use `path.resolve` and added a check to ensure the resolved path starts with the base tests directory. If not, the server responds with a 403 Forbidden status, mitigating potential path traversal attacks. (`server.cjs`, [server.cjsR4-R36](diffhunk://#diff-b5c2c6826250db328d90f6217a5c2cd8e9b55a94de682d42c4028a3075564c6eR4-R36))