### PR TITLE
[DPEDE-4187] Algolia crawler script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ src/boilerplates/es6/chi-vue-es6-boilerplate/src/es6
 # Backup files
 *.bak
 *.scss*
+
+# Env
+.env

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "tests:visual:run": "bash ./scripts/tests/visualTests.sh",
     "tests:visual:approve": "node ./scripts/tests/approve.js",
     "tests:e2e": "bash ./scripts/tests/e2eTests.sh",
-    "lint:scss": "sass-lint -v -q"
+    "lint:scss": "sass-lint -v -q",
+    "postrelease:algolia": "bash ./scripts/reindexAlgolia.sh"
   },
   "dependencies": {
     "@centurylink/chi-custom-elements": "1.23.0",

--- a/scripts/reindexAlgolia.sh
+++ b/scripts/reindexAlgolia.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Script to reindex Algolia using the Algolia Crawler API
+# https://www.algolia.com/doc/rest-api/crawler/#section/Availability-and-authentication
 
 # Needs env variables ALGOLIA_USER_ID, ALGOLIA_API_KEY, ALGOLIA_CRAWLER_ID to be set
 source .env

--- a/scripts/reindexAlgolia.sh
+++ b/scripts/reindexAlgolia.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-# Needs env variables USER_ID, API_KEY, CRAWLER_ID to be set
+# Needs env variables ALGOLIA_USER_ID, ALGOLIA_API_KEY, ALGOLIA_CRAWLER_ID to be set
 source .env
 
 SITEMAP="dist/sitemap.xml"
 
 # Base64 encode your credentials
-CREDENTIALS=$(echo -n "${USER_ID}:${API_KEY}" | base64)
+CREDENTIALS=$(echo -n "${ALGOLIA_USER_ID}:${ALGOLIA_API_KEY}" | base64)
 
 check_task_status() {
-  local task_id="$1"
-  
-  TASK_STATUS=$(curl -s -X GET "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/tasks/${TASK_ID}" \
+  local TASK_ID="$1"
+
+  TASK_STATUS=$(curl -s -X GET "https://crawler.algolia.com/api/1/crawlers/${ALGOLIA_CRAWLER_ID}/tasks/${TASK_ID}" \
   -H "Authorization: Basic ${CREDENTIALS}" \
   -H "Content-Type: application/json" | jq -r '.pending')
 
   if [ "$TASK_STATUS" == "true" ]; then
     echo "🔄 Task is still pending. Retrying in 1 second..."
     sleep 1
-    check_task_status "$task_id"
+    check_task_status "$TASK_ID"
   fi
 }
 
@@ -26,7 +26,7 @@ check_task_status() {
 # CRAWL ALL PAGES
 # 
 crawl_all_site() {
-  RESPONSE=$(curl -s -X POST "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/reindex" \
+  RESPONSE=$(curl -s -X POST "https://crawler.algolia.com/api/1/crawlers/${ALGOLIA_CRAWLER_ID}/reindex" \
     -H "Authorization: Basic ${CREDENTIALS}" \
     -H "Content-Type: application/json")
 
@@ -53,7 +53,7 @@ crawl_url() {
     exit 1
   fi
 
-  RESPONSE=$(curl -s -X POST "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/urls/crawl" \
+  RESPONSE=$(curl -s -X POST "https://crawler.algolia.com/api/1/crawlers/${ALGOLIA_CRAWLER_ID}/urls/crawl" \
     -H "Authorization: Basic ${CREDENTIALS}" \
     -H "Content-Type: application/json" \
     -d "{\"urls\": [\"$url\"], \"save\": true}")
@@ -103,7 +103,7 @@ crawl_from_latest_version() {
   echo START_URL: $BASE_URL
 
   # UPDATE CRAWLER CONFIGURATION 
-  RESPONSE=$(curl -s -X PATCH "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/config" \
+  RESPONSE=$(curl -s -X PATCH "https://crawler.algolia.com/api/1/crawlers/${ALGOLIA_CRAWLER_ID}/config" \
     -H "Authorization: Basic ${CREDENTIALS}" \
     -H "Content-Type: application/json" \
     -d "{\"startUrls\": [\"$BASE_URL/getting-started\"], \"sitemaps\": [\"$BASE_URL/sitemap.xml\"]}")

--- a/scripts/reindexAlgolia.sh
+++ b/scripts/reindexAlgolia.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Needs env variables USER_ID, API_KEY, CRAWLER_ID to be set
+source .env
+
+SITEMAP="dist/sitemap.xml"
+
+# Base64 encode your credentials
+CREDENTIALS=$(echo -n "${USER_ID}:${API_KEY}" | base64)
+
+check_task_status() {
+  local task_id="$1"
+  
+  TASK_STATUS=$(curl -s -X GET "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/tasks/${TASK_ID}" \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/json" | jq -r '.pending')
+
+  if [ "$TASK_STATUS" == "true" ]; then
+    echo "🔄 Task is still pending. Retrying in 1 second..."
+    sleep 1
+    check_task_status "$task_id"
+  fi
+}
+
+# 
+# CRAWL ALL PAGES
+# 
+crawl_all_site() {
+  RESPONSE=$(curl -s -X POST "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/reindex" \
+    -H "Authorization: Basic ${CREDENTIALS}" \
+    -H "Content-Type: application/json")
+
+  TASK_ID=$(echo "$RESPONSE" | jq -r '.taskId')
+
+  # Step 3: Check if the TASK_ID was successfully captured
+  if [ -z "$TASK_ID" ] || [ "$TASK_ID" == "null" ]; then
+    echo "❌ Error: Failed to retrieve a valid taskId. Please check the response: $RESPONSE"
+  fi
+
+  echo "✅ Success! Task started with taskId: ${TASK_ID}"
+
+  check_task_status "$TASK_ID" "$CREDENTIALS"
+}
+
+# 
+# CRAWL SINGLE URL
+# 
+crawl_url() {
+  local url="$1"
+
+  if [ -z "$url" ]; then
+    echo "❌ Error: No URL provided for crawling."
+    exit 1
+  fi
+
+  RESPONSE=$(curl -s -X POST "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/urls/crawl" \
+    -H "Authorization: Basic ${CREDENTIALS}" \
+    -H "Content-Type: application/json" \
+    -d "{\"urls\": [\"$url\"], \"save\": true}")
+
+  TASK_ID=$(echo "$RESPONSE" | jq -r '.taskId')
+
+  if [ -z "$TASK_ID" ] || [ "$TASK_ID" == "null" ]; then
+    echo "❌ Error: Failed to retrieve a valid taskId for URL $url. Please check the response: $RESPONSE"
+    exit 1
+  fi
+
+  # wait for task to be completed 
+  sleep 2
+
+  check_task_status "$TASK_ID" "$CREDENTIALS"
+}
+
+# 
+# CRAWLS URLS FROM SITEMAP
+# 
+crawl_sitemap() {
+  if [ ! -f "$SITEMAP" ]; then
+    echo "❌ Error: Sitemap file not found at $SITEMAP"
+    exit 1
+  fi
+
+  URLS=$(grep -e loc $SITEMAP | sed 's|<loc>\(.*\)<\/loc>$|\1|g')
+
+  if [ -z "$URLS" ]; then
+    echo "❌ Error: No URLs found in the sitemap."
+    exit 1
+  fi
+
+  for url in $URLS
+  do 
+    echo "🔄 Crawling URL: $url"
+    crawl_url "$url"
+  done
+}
+
+# 
+# UPDATE CRAWLER CONFIGURATION TO START FROM LATEST VERSION AND CRAWLS SITE
+# 
+crawl_from_latest_version() {
+  BASE_URL=$(grep -e loc $SITEMAP | head -1 | sed 's|<loc>\(.*\)<\/loc>$|\1|')
+
+  echo START_URL: $BASE_URL
+
+  # UPDATE CRAWLER CONFIGURATION 
+  RESPONSE=$(curl -s -X PATCH "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/config" \
+    -H "Authorization: Basic ${CREDENTIALS}" \
+    -H "Content-Type: application/json" \
+    -d "{\"startUrls\": [\"$BASE_URL/getting-started\"], \"sitemaps\": [\"$BASE_URL/sitemap.xml\"]}")
+
+  TASK_ID=$(echo "$RESPONSE" | jq -r '.taskId')
+
+  check_task_status "$TASK_ID"
+
+  crawl_all_site
+
+  echo "✅ Crawling from latest version started successfully."
+}
+
+crawl_from_latest_version


### PR DESCRIPTION
This pull request introduces a new feature to reindex Algolia using a custom script and updates the package.json file to include a new npm script for this functionality. The changes primarily involve adding the postrelease:algolia script and implementing the reindexAlgolia.sh script.

New Algolia Reindexing Feature:
package.json: Added a new npm script, postrelease:algolia, which runs the reindexAlgolia.sh script to reindex Algolia after a release.
scripts/reindexAlgolia.sh: Introduced a new Bash script to reindex Algolia using its Crawler API. The script supports multiple operations:
Reindexing the entire site.
Crawling a single URL.
Crawling URLs from a sitemap.
Updating the crawler configuration to start from the latest version before crawling.