### PR TITLE
[DPEDE-6708] Make chi alert actions slot dynamic in alert web component

### DIFF
--- a/.cursor/chi/skills/chi-component-schemas/schemas.json
+++ b/.cursor/chi/skills/chi-component-schemas/schemas.json
@@ -147,7 +147,8 @@
       "-banner-background-color",
       "-bubble-background-color",
       "-color",
-      "-title-color"
+      "-title-color",
+      "-hidden"
     ],
     "conflictingModifiers": [
       [
@@ -695,7 +696,8 @@
       "-float",
       "-dots",
       "-pagination",
-      "-active"
+      "-active",
+      "-fade"
     ],
     "accessibility": {}
   },

--- a/.cursor/chi/skills/chi-components/reference.md
+++ b/.cursor/chi/skills/chi-components/reference.md
@@ -69,7 +69,7 @@
 |-----------|------------|-----------|---------------|---------------|
 | accordion | chi-accordion | -disabled, -transitioning, -expanded, -truncated, -card, -sm, -link, -compact-title, ... | chi-accordion__item | `<chi-accordion>` |
 | activity | chi-activity | -feed, -compact, -stories | chi-activity__day, chi-activity__item |  |
-| alert | chi-alert | -center, -banner, -close, -lg, -sm, -hover, -success, -border-color, ... | chi-alert__content | `<chi-alert>` |
+| alert | chi-alert | -center, -banner, -close, -hidden, -lg, -sm, -hover, -success, ... | chi-alert__content | `<chi-alert>` |
 | anchor-nav | chi-anchor-nav | -active |  |  |
 | avatars | chi-avatar | -transparent, -xs, -sm, -sm--2, -sm--3, -md, -lg, -xl, ... |  |  |
 | backdrop | chi-backdrop | -full-page, -center, -mobile-bottom, -animated, -closed, -inverse, -transitioning | chi-backdrop__wrapper, chi-backdrop__footer | `<chi-backdrop>` |

--- a/src/chi/components/alert/_alert-common.scss
+++ b/src/chi/components/alert/_alert-common.scss
@@ -209,6 +209,10 @@ $states: (
     .chi-alert__actions {
       padding-top: 0.75rem;
 
+      &.-hidden {
+        display: none;
+      }
+
       > .chi-button {
         margin-right: 0.5rem;
 


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-6708

This pull request introduces a new `-hidden` modifier for the `chi-alert` component, allowing alerts (and their actions) to be easily hidden via a CSS class. It also adds a new `-fade` modifier to the `carousel` component. These changes update both the component schemas and documentation to reflect the new modifiers.

**Component modifier additions:**

* Added the `-hidden` modifier to the `chi-alert` component schema in `.cursor/chi/skills/chi-component-schemas/schemas.json`, enabling alerts to be hidden via a class.
* Added the `-fade` modifier to the `carousel` component schema in `.cursor/chi/skills/chi-component-schemas/schemas.json`.

**Documentation updates:**

* Updated the `chi-alert` entry in `.cursor/chi/skills/chi-components/reference.md` to include the new `-hidden` modifier in the list of supported modifiers.

**SCSS implementation:**

* Implemented the `-hidden` modifier in `src/chi/components/alert/_alert-common.scss` by adding a rule to hide elements with the `-hidden` class.