### PR TITLE
[DPEDE-6787] Update progress bar to latest connect styles

### DIFF
--- a/src/chi/components/progress/progress.scss
+++ b/src/chi/components/progress/progress.scss
@@ -5,40 +5,40 @@ $states: (
   danger: (
     background-color: $progress-value-danger-background-color,
   ),
-  warning: (
-    background-color: $progress-value-warning-background-color,
-  ),
   info: (
     background-color: $progress-value-info-background-color,
   ),
   success: (
     background-color: $progress-value-success-background-color,
   ),
+  warning: (
+    background-color: $progress-value-warning-background-color,
+  ),
 );
+
+.chi-progress__bar {
+  span {
+    color: $progress-percentage-color;
+    font-size: $progress-percentage-font-size;
+    font-weight: $progress-percentage-font-weight;
+  }
+}
 
 .chi-progress__bar,
 .chi-progress__label {
   align-items: center;
-  color: $color-grey-60;
+  color: $progress-bar-label-color;
   display: flex;
-  font-size: 0.8125rem;
-  gap: 0.5rem;
+  font-size: $progress-bar-label-font-size;
+  gap: $progress-bar-label-gap;
 }
 
 .chi-progress__label {
-  margin-top: 0.6rem;
+  margin-top: $progress-label-margin-top;
 
   chi-spinner.sc-chi-spinner-h {
     align-items: center;
     display: flex;
-  }
-}
-
-.chi-progress__bar {
-  span {
-    color: $color-grey-100;
-    font-size: 0.9rem;
-    font-weight: 500;
   }
 }
 
@@ -49,14 +49,19 @@ progress {
   -webkit-appearance: none;
   appearance: none;
   /* Get rid of default border in Firefox. */
-  border: 0;
   border-radius: $progress-border-radius;
+  border: $progress-track-border;
   color: $progress-value-background-color;
   display: block;
   height: $progress-height;
   overflow: hidden;
   width: 100%;
-  border: 1px solid $color-grey-30;
+
+  //Firefox
+  &::-moz-progress-bar {
+    background-color: $progress-value-background-color;
+    border-radius: $progress-border-radius;
+  }
 
   //Chrome, Safari
   &::-webkit-progress-bar {
@@ -68,21 +73,15 @@ progress {
     border-radius: $progress-border-radius;
   }
 
-  //Firefox
-  &::-moz-progress-bar {
-    background-color: $progress-value-background-color;
-    border-radius: $progress-border-radius;
-  }
-
   @each $state in map-keys($states) {
     &.-#{$state} {
       color: map-get(map-get($states, $state), background-color);
 
-      &::-webkit-progress-value {
+      &::-moz-progress-bar {
         background-color: map-get(map-get($states, $state), background-color);
       }
 
-      &::-moz-progress-bar {
+      &::-webkit-progress-value {
         background-color: map-get(map-get($states, $state), background-color);
       }
     }

--- a/src/chi/components/progress/progress.scss
+++ b/src/chi/components/progress/progress.scss
@@ -16,6 +16,32 @@ $states: (
   ),
 );
 
+.chi-progress__bar,
+.chi-progress__label {
+  align-items: center;
+  color: $color-grey-60;
+  display: flex;
+  font-size: 0.8125rem;
+  gap: 0.5rem;
+}
+
+.chi-progress__label {
+  margin-top: 0.6rem;
+
+  chi-spinner.sc-chi-spinner-h {
+    align-items: center;
+    display: flex;
+  }
+}
+
+.chi-progress__bar {
+  span {
+    color: $color-grey-100;
+    font-size: 0.9rem;
+    font-weight: 500;
+  }
+}
+
 progress {
   // sass-lint:disable-block no-vendor-prefixes
   /* Reset the default appearance */
@@ -30,6 +56,7 @@ progress {
   height: $progress-height;
   overflow: hidden;
   width: 100%;
+  border: 1px solid $color-grey-30;
 
   //Chrome, Safari
   &::-webkit-progress-bar {
@@ -38,11 +65,13 @@ progress {
 
   &::-webkit-progress-value {
     background-color: $progress-value-background-color;
+    border-radius: $progress-border-radius;
   }
 
   //Firefox
   &::-moz-progress-bar {
     background-color: $progress-value-background-color;
+    border-radius: $progress-border-radius;
   }
 
   @each $state in map-keys($states) {

--- a/src/chi/components/progress/progress.scss
+++ b/src/chi/components/progress/progress.scss
@@ -70,7 +70,7 @@ progress {
 
   &::-webkit-progress-value {
     background-color: $progress-value-background-color;
-    border-radius: $progress-border-radius;
+    border-radius: $progress-value-border-radius;
   }
 
   @each $state in map-keys($states) {

--- a/src/chi/components/progress/progress.scss
+++ b/src/chi/components/progress/progress.scss
@@ -36,7 +36,7 @@ $states: (
 .chi-progress__label {
   margin-top: $progress-label-margin-top;
 
-  chi-spinner.sc-chi-spinner-h {
+  chi-spinner {
     align-items: center;
     display: flex;
   }

--- a/src/chi/themes/brightspeed/_variables.scss
+++ b/src/chi/themes/brightspeed/_variables.scss
@@ -2129,13 +2129,21 @@ $popover-gradient-accent-1-arrow-mixed-color: initial;
 
 // Progress
 $progress-background-color:                 $color-grey-20;
-$progress-border-radius:                    $border-radius-base;
 $progress-height:                           0.5rem;
+$progress-border-radius:                    calc($progress-height / 2);
 $progress-value-background-color:           $color-background-primary;
 $progress-value-info-background-color:      $color-icon-info;
 $progress-value-danger-background-color:    $color-icon-danger;
 $progress-value-success-background-color:   $color-icon-success;
 $progress-value-warning-background-color:   $color-icon-warning;
+$progress-bar-label-color:                  $color-grey-60;
+$progress-bar-label-font-size:            0.8125rem;
+$progress-bar-label-gap:                  0.5rem;
+$progress-label-margin-top:               0.6rem;
+$progress-percentage-color:               $color-grey-100;
+$progress-percentage-font-size:           0.9rem;
+$progress-percentage-font-weight:         500;
+$progress-track-border:                   0.0625rem solid $color-grey-30;
 
 // Radio button
 $radio-background-color:                    $color-background-white;

--- a/src/chi/themes/brightspeed/_variables.scss
+++ b/src/chi/themes/brightspeed/_variables.scss
@@ -2131,6 +2131,7 @@ $popover-gradient-accent-1-arrow-mixed-color: initial;
 $progress-background-color:                 $color-grey-20;
 $progress-height:                           0.5rem;
 $progress-border-radius:                    0;
+$progress-value-border-radius:              0;
 $progress-value-background-color:           $color-background-primary;
 $progress-value-info-background-color:      $color-icon-info;
 $progress-value-danger-background-color:    $color-icon-danger;

--- a/src/chi/themes/brightspeed/_variables.scss
+++ b/src/chi/themes/brightspeed/_variables.scss
@@ -2130,20 +2130,20 @@ $popover-gradient-accent-1-arrow-mixed-color: initial;
 // Progress
 $progress-background-color:                 $color-grey-20;
 $progress-height:                           0.5rem;
-$progress-border-radius:                    calc($progress-height / 2);
+$progress-border-radius:                    0;
 $progress-value-background-color:           $color-background-primary;
 $progress-value-info-background-color:      $color-icon-info;
 $progress-value-danger-background-color:    $color-icon-danger;
 $progress-value-success-background-color:   $color-icon-success;
 $progress-value-warning-background-color:   $color-icon-warning;
 $progress-bar-label-color:                  $color-grey-60;
-$progress-bar-label-font-size:            0.8125rem;
-$progress-bar-label-gap:                  0.5rem;
-$progress-label-margin-top:               0.6rem;
-$progress-percentage-color:               $color-grey-100;
-$progress-percentage-font-size:           0.9rem;
-$progress-percentage-font-weight:         500;
-$progress-track-border:                   0.0625rem solid $color-grey-30;
+$progress-bar-label-font-size:              0.8125rem;
+$progress-bar-label-gap:                    0.5rem;
+$progress-label-margin-top:                 0.6rem;
+$progress-percentage-color:                 $color-grey-100;
+$progress-percentage-font-size:             0.9rem;
+$progress-percentage-font-weight:           500;
+$progress-track-border:                     0;
 
 // Radio button
 $radio-background-color:                    $color-background-white;

--- a/src/chi/themes/centurylink/_variables.scss
+++ b/src/chi/themes/centurylink/_variables.scss
@@ -2148,6 +2148,7 @@ $progress-background-color:                 $color-grey-20;
 $progress-height:                           0.5rem;
 $progress-border-radius:                    0;
 $progress-value-background-color:           $color-background-primary;
+$progress-value-border-radius:              0;
 $progress-value-info-background-color:      $color-icon-info;
 $progress-value-danger-background-color:    $color-icon-danger;
 $progress-value-success-background-color:   $color-icon-success;

--- a/src/chi/themes/centurylink/_variables.scss
+++ b/src/chi/themes/centurylink/_variables.scss
@@ -2145,13 +2145,21 @@ $popover-gradient-accent-1-arrow-mixed-color: initial;
 
 // Progress
 $progress-background-color:                 $color-grey-20;
-$progress-border-radius:                    $border-radius-base;
 $progress-height:                           0.5rem;
+$progress-border-radius:                    calc($progress-height / 2);
 $progress-value-background-color:           $color-background-primary;
 $progress-value-info-background-color:      $color-icon-info;
 $progress-value-danger-background-color:    $color-icon-danger;
 $progress-value-success-background-color:   $color-icon-success;
 $progress-value-warning-background-color:   $color-icon-warning;
+$progress-bar-label-color:                  $color-grey-60;
+$progress-bar-label-font-size:            0.8125rem;
+$progress-bar-label-gap:                  0.5rem;
+$progress-label-margin-top:               0.6rem;
+$progress-percentage-color:               $color-grey-100;
+$progress-percentage-font-size:           0.9rem;
+$progress-percentage-font-weight:         500;
+$progress-track-border:                   0.0625rem solid $color-grey-30;
 
 // Radio button
 $radio-background-color:                    $color-background-white;

--- a/src/chi/themes/centurylink/_variables.scss
+++ b/src/chi/themes/centurylink/_variables.scss
@@ -2146,20 +2146,20 @@ $popover-gradient-accent-1-arrow-mixed-color: initial;
 // Progress
 $progress-background-color:                 $color-grey-20;
 $progress-height:                           0.5rem;
-$progress-border-radius:                    calc($progress-height / 2);
+$progress-border-radius:                    0;
 $progress-value-background-color:           $color-background-primary;
 $progress-value-info-background-color:      $color-icon-info;
 $progress-value-danger-background-color:    $color-icon-danger;
 $progress-value-success-background-color:   $color-icon-success;
 $progress-value-warning-background-color:   $color-icon-warning;
 $progress-bar-label-color:                  $color-grey-60;
-$progress-bar-label-font-size:            0.8125rem;
-$progress-bar-label-gap:                  0.5rem;
-$progress-label-margin-top:               0.6rem;
-$progress-percentage-color:               $color-grey-100;
-$progress-percentage-font-size:           0.9rem;
-$progress-percentage-font-weight:         500;
-$progress-track-border:                   0.0625rem solid $color-grey-30;
+$progress-bar-label-font-size:              0.8125rem;
+$progress-bar-label-gap:                    0.5rem;
+$progress-label-margin-top:                 0.6rem;
+$progress-percentage-color:                 $color-grey-100;
+$progress-percentage-font-size:             0.9rem;
+$progress-percentage-font-weight:           500;
+$progress-track-border:                     0;
 
 // Radio button
 $radio-background-color:                    $color-background-white;

--- a/src/chi/themes/colt/_variables.scss
+++ b/src/chi/themes/colt/_variables.scss
@@ -2143,20 +2143,20 @@ $popover-gradient-accent-1-arrow-mixed-color: initial;
 // Progress
 $progress-background-color:                 $color-grey-20;
 $progress-height:                           0.5rem;
-$progress-border-radius:                    calc($progress-height / 2);
+$progress-border-radius:                    0;
 $progress-value-background-color:           $color-background-primary;
 $progress-value-info-background-color:      $color-icon-info;
 $progress-value-danger-background-color:    $color-icon-danger;
 $progress-value-success-background-color:   $color-icon-success;
 $progress-value-warning-background-color:   $color-icon-warning;
 $progress-bar-label-color:                  $color-grey-60;
-$progress-bar-label-font-size:            0.8125rem;
-$progress-bar-label-gap:                  0.5rem;
-$progress-label-margin-top:               0.6rem;
-$progress-percentage-color:               $color-grey-100;
-$progress-percentage-font-size:           0.9rem;
-$progress-percentage-font-weight:         500;
-$progress-track-border:                   0.0625rem solid $color-grey-30;
+$progress-bar-label-font-size:              0.8125rem;
+$progress-bar-label-gap:                    0.5rem;
+$progress-label-margin-top:                 0.6rem;
+$progress-percentage-color:                 $color-grey-100;
+$progress-percentage-font-size:             0.9rem;
+$progress-percentage-font-weight:           500;
+$progress-track-border:                     0;
 
 // Radio button
 $radio-background-color:                    $color-background-white;

--- a/src/chi/themes/colt/_variables.scss
+++ b/src/chi/themes/colt/_variables.scss
@@ -2144,6 +2144,7 @@ $popover-gradient-accent-1-arrow-mixed-color: initial;
 $progress-background-color:                 $color-grey-20;
 $progress-height:                           0.5rem;
 $progress-border-radius:                    0;
+$progress-value-border-radius:              0;
 $progress-value-background-color:           $color-background-primary;
 $progress-value-info-background-color:      $color-icon-info;
 $progress-value-danger-background-color:    $color-icon-danger;

--- a/src/chi/themes/colt/_variables.scss
+++ b/src/chi/themes/colt/_variables.scss
@@ -2142,13 +2142,21 @@ $popover-gradient-accent-1-arrow-mixed-color: initial;
 
 // Progress
 $progress-background-color:                 $color-grey-20;
-$progress-border-radius:                    $border-radius-base;
 $progress-height:                           0.5rem;
+$progress-border-radius:                    calc($progress-height / 2);
 $progress-value-background-color:           $color-background-primary;
 $progress-value-info-background-color:      $color-icon-info;
 $progress-value-danger-background-color:    $color-icon-danger;
 $progress-value-success-background-color:   $color-icon-success;
 $progress-value-warning-background-color:   $color-icon-warning;
+$progress-bar-label-color:                  $color-grey-60;
+$progress-bar-label-font-size:            0.8125rem;
+$progress-bar-label-gap:                  0.5rem;
+$progress-label-margin-top:               0.6rem;
+$progress-percentage-color:               $color-grey-100;
+$progress-percentage-font-size:           0.9rem;
+$progress-percentage-font-weight:         500;
+$progress-track-border:                   0.0625rem solid $color-grey-30;
 
 // Radio button
 $radio-background-color:                    $color-background-white;

--- a/src/chi/themes/connect/_variables.scss
+++ b/src/chi/themes/connect/_variables.scss
@@ -2176,6 +2176,7 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 $progress-background-color: $color-grey-20;
 $progress-height: 1rem;
 $progress-border-radius: calc($progress-height / 2);
+$progress-value-border-radius: $progress-border-radius;
 $progress-value-background-color: $color-teal-100;
 $progress-value-info-background-color: $color-teal-60;
 $progress-value-danger-background-color: $color-red-50;

--- a/src/chi/themes/connect/_variables.scss
+++ b/src/chi/themes/connect/_variables.scss
@@ -2174,10 +2174,10 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 
 // Progress
 $progress-background-color: $color-grey-20;
-$progress-border-radius: 0.3125rem;
+$progress-border-radius: 99px;
 $progress-height: 1rem;
 $progress-value-background-color: $color-teal-100;
-$progress-value-info-background-color: $color-blue-50;
+$progress-value-info-background-color: $color-teal-60;
 $progress-value-danger-background-color: $color-red-50;
 $progress-value-success-background-color: $color-green-50;
 $progress-value-warning-background-color: $color-yellow-50;

--- a/src/chi/themes/connect/_variables.scss
+++ b/src/chi/themes/connect/_variables.scss
@@ -2174,13 +2174,21 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 
 // Progress
 $progress-background-color: $color-grey-20;
-$progress-border-radius: 99px;
 $progress-height: 1rem;
+$progress-border-radius: calc($progress-height / 2);
 $progress-value-background-color: $color-teal-100;
 $progress-value-info-background-color: $color-teal-60;
 $progress-value-danger-background-color: $color-red-50;
 $progress-value-success-background-color: $color-green-50;
 $progress-value-warning-background-color: $color-yellow-50;
+$progress-bar-label-color: $color-grey-60;
+$progress-bar-label-font-size: 0.8125rem;
+$progress-bar-label-gap: 0.5rem;
+$progress-label-margin-top: 0.6rem;
+$progress-percentage-color: $color-grey-100;
+$progress-percentage-font-size: 0.9rem;
+$progress-percentage-font-weight: 500;
+$progress-track-border: 0.0625rem solid $color-grey-30;
 
 // Radio button
 // Needed because box-shadow with rgba and opacity doesn't work

--- a/src/chi/themes/lumen/_variables.scss
+++ b/src/chi/themes/lumen/_variables.scss
@@ -2169,7 +2169,7 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 // Progress
 $progress-background-color: $color-grey-20;
 $progress-height: 0.5rem;
-$progress-border-radius: calc($progress-height / 2);
+$progress-border-radius: 0;
 $progress-value-background-color: $color-background-primary;
 $progress-value-info-background-color: $color-icon-info;
 $progress-value-danger-background-color: $color-icon-danger;
@@ -2182,7 +2182,7 @@ $progress-label-margin-top: 0.6rem;
 $progress-percentage-color: $color-grey-100;
 $progress-percentage-font-size: 0.9rem;
 $progress-percentage-font-weight: 500;
-$progress-track-border: 0.0625rem solid $color-grey-30;
+$progress-track-border: 0;
 
 // Radio button
 $radio-background-color: $color-background-white;

--- a/src/chi/themes/lumen/_variables.scss
+++ b/src/chi/themes/lumen/_variables.scss
@@ -2168,13 +2168,21 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 
 // Progress
 $progress-background-color: $color-grey-20;
-$progress-border-radius: $border-radius-base;
 $progress-height: 0.5rem;
+$progress-border-radius: calc($progress-height / 2);
 $progress-value-background-color: $color-background-primary;
 $progress-value-info-background-color: $color-icon-info;
 $progress-value-danger-background-color: $color-icon-danger;
 $progress-value-success-background-color: $color-icon-success;
 $progress-value-warning-background-color: $color-icon-warning;
+$progress-bar-label-color: $color-grey-60;
+$progress-bar-label-font-size: 0.8125rem;
+$progress-bar-label-gap: 0.5rem;
+$progress-label-margin-top: 0.6rem;
+$progress-percentage-color: $color-grey-100;
+$progress-percentage-font-size: 0.9rem;
+$progress-percentage-font-weight: 500;
+$progress-track-border: 0.0625rem solid $color-grey-30;
 
 // Radio button
 $radio-background-color: $color-background-white;

--- a/src/chi/themes/lumen/_variables.scss
+++ b/src/chi/themes/lumen/_variables.scss
@@ -2169,7 +2169,8 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 // Progress
 $progress-background-color: $color-grey-20;
 $progress-height: 0.5rem;
-$progress-border-radius: 0;
+$progress-border-radius: calc($progress-height / 2);
+$progress-value-border-radius: 0;
 $progress-value-background-color: $color-background-primary;
 $progress-value-info-background-color: $color-icon-info;
 $progress-value-danger-background-color: $color-icon-danger;

--- a/src/chi/themes/portal/_variables.scss
+++ b/src/chi/themes/portal/_variables.scss
@@ -2169,7 +2169,7 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 // Progress
 $progress-background-color: $color-grey-20;
 $progress-height: 0.5rem;
-$progress-border-radius: calc($progress-height / 2);
+$progress-border-radius: 0;
 $progress-value-background-color: $color-background-primary;
 $progress-value-info-background-color: $color-icon-info;
 $progress-value-danger-background-color: $color-icon-danger;
@@ -2182,7 +2182,7 @@ $progress-label-margin-top: 0.6rem;
 $progress-percentage-color: $color-grey-100;
 $progress-percentage-font-size: 0.9rem;
 $progress-percentage-font-weight: 500;
-$progress-track-border: 0.0625rem solid $color-grey-30;
+$progress-track-border: 0;
 
 // Radio button
 $radio-background-color: $color-background-white;

--- a/src/chi/themes/portal/_variables.scss
+++ b/src/chi/themes/portal/_variables.scss
@@ -2170,6 +2170,7 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 $progress-background-color: $color-grey-20;
 $progress-height: 0.5rem;
 $progress-border-radius: 0;
+$progress-value-border-radius: 0;
 $progress-value-background-color: $color-background-primary;
 $progress-value-info-background-color: $color-icon-info;
 $progress-value-danger-background-color: $color-icon-danger;

--- a/src/chi/themes/portal/_variables.scss
+++ b/src/chi/themes/portal/_variables.scss
@@ -2168,13 +2168,21 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 
 // Progress
 $progress-background-color: $color-grey-20;
-$progress-border-radius: $border-radius-base;
 $progress-height: 0.5rem;
+$progress-border-radius: calc($progress-height / 2);
 $progress-value-background-color: $color-background-primary;
 $progress-value-info-background-color: $color-icon-info;
 $progress-value-danger-background-color: $color-icon-danger;
 $progress-value-success-background-color: $color-icon-success;
 $progress-value-warning-background-color: $color-icon-warning;
+$progress-bar-label-color: $color-grey-60;
+$progress-bar-label-font-size: 0.8125rem;
+$progress-bar-label-gap: 0.5rem;
+$progress-label-margin-top: 0.6rem;
+$progress-percentage-color: $color-grey-100;
+$progress-percentage-font-size: 0.9rem;
+$progress-percentage-font-weight: 500;
+$progress-track-border: 0.0625rem solid $color-grey-30;
 
 // Radio button
 $radio-background-color: $color-background-white;

--- a/src/chi/themes/test/_variables.scss
+++ b/src/chi/themes/test/_variables.scss
@@ -2221,13 +2221,21 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 
 // Progress
 $progress-background-color: $color-grey-20;
-$progress-border-radius: 0.3125rem;
 $progress-height: 1rem;
+$progress-border-radius: calc($progress-height / 2);
 $progress-value-background-color: $color-teal-100;
 $progress-value-info-background-color: $color-blue-50;
 $progress-value-danger-background-color: $color-red-50;
 $progress-value-success-background-color: $color-green-50;
 $progress-value-warning-background-color: $color-yellow-50;
+$progress-bar-label-color: $color-grey-60;
+$progress-bar-label-font-size: 0.8125rem;
+$progress-bar-label-gap: 0.5rem;
+$progress-label-margin-top: 0.6rem;
+$progress-percentage-color: $color-grey-100;
+$progress-percentage-font-size: 0.9rem;
+$progress-percentage-font-weight: 500;
+$progress-track-border: 0.0625rem solid $color-grey-30;
 
 // Radio button
 // Needed because box-shadow with rgba and opacity doesn't work

--- a/src/chi/themes/test/_variables.scss
+++ b/src/chi/themes/test/_variables.scss
@@ -2223,6 +2223,7 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 $progress-background-color: $color-grey-20;
 $progress-height: 1rem;
 $progress-border-radius: 0;
+$progress-value-border-radius: 0;
 $progress-value-background-color: $color-teal-100;
 $progress-value-info-background-color: $color-blue-50;
 $progress-value-danger-background-color: $color-red-50;

--- a/src/chi/themes/test/_variables.scss
+++ b/src/chi/themes/test/_variables.scss
@@ -2222,7 +2222,7 @@ $popover-gradient-accent-1-arrow-mixed-color: mix($color-teal-80, $color-teal-70
 // Progress
 $progress-background-color: $color-grey-20;
 $progress-height: 1rem;
-$progress-border-radius: calc($progress-height / 2);
+$progress-border-radius: 0;
 $progress-value-background-color: $color-teal-100;
 $progress-value-info-background-color: $color-blue-50;
 $progress-value-danger-background-color: $color-red-50;
@@ -2235,7 +2235,7 @@ $progress-label-margin-top: 0.6rem;
 $progress-percentage-color: $color-grey-100;
 $progress-percentage-font-size: 0.9rem;
 $progress-percentage-font-weight: 500;
-$progress-track-border: 0.0625rem solid $color-grey-30;
+$progress-track-border: 0;
 
 // Radio button
 // Needed because box-shadow with rgba and opacity doesn't work


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-6787

This pull request updates the styling of the progress component to improve its appearance and consistency. The main changes include adjustments to the progress bar's border and border radius, color updates, and enhanced alignment and layout for labels and spinners.

**Progress component style improvements:**

* Increased the `progress` bar's border radius to `99px` for a more rounded appearance and added a border with color `$color-grey-30` (`src/chi/themes/connect/_variables.scss`, `src/chi/components/progress/progress.scss`) [[1]](diffhunk://#diff-b5fafe481b0c804a8a866ac71a02214f0bafdbbacb30b8d82a7b737f644fe3f2L2177-R2180) [[2]](diffhunk://#diff-785150e3c84b54e993d111560f65bb9adb1a2101ca15ec4b1e9accd6f37d0bdaR59) [[3]](diffhunk://#diff-785150e3c84b54e993d111560f65bb9adb1a2101ca15ec4b1e9accd6f37d0bdaR68-R74)
* Updated the background color for the "info" state of the progress bar to `$color-teal-60` for better visual consistency (`src/chi/themes/connect/_variables.scss`)

**Progress bar and label layout enhancements:**

* Added shared styles to `.chi-progress__bar` and `.chi-progress__label` for better alignment, spacing, and font styling, and improved the layout for spinners inside labels (`src/chi/components/progress/progress.scss`)
* Updated the color and font styling of the text inside the progress bar for improved readability (`src/chi/components/progress/progress.scss`)