### PR TITLE
[DPEDE-6894] Added picker group web component styles

### DIFF
--- a/src/chi/components/picker/_picker-group-component.scss
+++ b/src/chi/components/picker/_picker-group-component.scss
@@ -1,0 +1,153 @@
+chi-picker-group {
+  .chi-picker-group__content {
+    .chi-picker-group__item,
+    chi-tooltip {
+      display: contents;
+    }
+
+    chi-tooltip > div {
+      display: flex;
+    }
+  }
+
+  .chi-picker-group:not(.-fluid) .chi-picker-group__content {
+    > .chi-picker-group__item:first-child input.chi-picker__input + label {
+      border-bottom-left-radius: $border-radius;
+      border-bottom-right-radius: 0;
+      border-top-left-radius: $border-radius;
+      border-top-right-radius: 0;
+    }
+
+    > .chi-picker-group__item:last-child input.chi-picker__input + label {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: $border-radius;
+      border-top-left-radius: 0;
+      border-top-right-radius: $border-radius;
+    }
+
+    // Overrides legacy :first-of-type + :last-of-type firing on every wrapped label.
+    > .chi-picker-group__item:not(:first-child):not(:last-child) input.chi-picker__input + label {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+
+    // Overrides legacy :last-of-type setting border-right on every wrapped label.
+    > .chi-picker-group__item:not(:last-child) input.chi-picker__input:not(:checked) + label {
+      border-right-width: 0;
+    }
+
+    > .chi-picker-group__item:has(input:checked) + .chi-picker-group__item label {
+      border-left-width: 0;
+      padding-left: $picker-group-md-padding-checked;
+
+      @each $type in map-keys($sizes) {
+        &.-#{$type} {
+          padding-left: map-get(map-get($sizes, $type), padding_checked);
+        }
+      }
+    }
+  }
+
+  .chi-picker-group.-fluid .chi-picker-group__content {
+    chi-tooltip > div {
+      flex: 1 0 auto;
+      width: 100%;
+
+      @include respond-to(md) {
+        flex: 1 0 0;
+      }
+    }
+
+    .chi-picker-group__item.-no-fluid chi-tooltip > div {
+      flex: 0 1 auto;
+
+      @include respond-to(md) {
+        width: auto;
+      }
+    }
+
+    > .chi-picker-group__item:first-child input.chi-picker__input + label {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      border-top-left-radius: $border-radius;
+      border-top-right-radius: $border-radius;
+
+      @include respond-to(md) {
+        border-bottom-left-radius: $border-radius;
+        border-bottom-right-radius: 0;
+        border-top-left-radius: $border-radius;
+        border-top-right-radius: 0;
+      }
+    }
+
+    > .chi-picker-group__item:last-child input.chi-picker__input + label {
+      border-bottom-left-radius: $border-radius;
+      border-bottom-right-radius: $border-radius;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+
+      @include respond-to(md) {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: $border-radius;
+        border-top-left-radius: 0;
+        border-top-right-radius: $border-radius;
+      }
+    }
+
+    // Overrides legacy :first-of-type + :last-of-type firing on every wrapped label.
+    > .chi-picker-group__item:not(:first-child):not(:last-child) input.chi-picker__input + label {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+
+    // Overrides legacy :last-of-type setting bottom (mobile) / right (md+) borders on every wrapped label.
+    > .chi-picker-group__item:not(:last-child) input.chi-picker__input:not(:checked) + label {
+      border-bottom-width: 0;
+
+      @include respond-to(md) {
+        border-bottom-width: 0.0625rem;
+        border-right-width: 0;
+      }
+    }
+
+    > .chi-picker-group__item:has(input:checked) + .chi-picker-group__item label {
+      border-left-width: 0.0625rem;
+      border-top-width: 0;
+      padding-left: $picker-group-md-padding-hover;
+
+      // Adds the md+ branch that legacy fluid's @each omits for sized labels.
+      @each $type in map-keys($sizes) {
+        &.-#{$type} {
+          padding-left: map-get(map-get($sizes, $type), padding_hover);
+
+          @include respond-to(md) {
+            padding-left: map-get(map-get($sizes, $type), padding_checked);
+          }
+        }
+      }
+
+      @include respond-to(md) {
+        border-left-width: 0;
+        border-top-width: 0.0625rem;
+        padding-left: $picker-group-md-padding-checked;
+      }
+    }
+
+    // Overrides legacy :checked + label:last-of-type over-firing on wrapped middle items.
+    > .chi-picker-group__item:not(:last-child) input.chi-picker__input:checked + label {
+      @include respond-to(md) {
+        padding-right: $picker-group-md-padding-hover;
+
+        @each $type in map-keys($sizes) {
+          &.-#{$type} {
+            padding-right: map-get(map-get($sizes, $type), padding_hover);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/chi/components/picker/picker-groups.scss
+++ b/src/chi/components/picker/picker-groups.scss
@@ -1,4 +1,5 @@
 @import '_horizontal-picker-groups';
+@import '_picker-group-component';
 
 .chi-picker-group {
   input {


### PR DESCRIPTION
This pull request introduces a new SCSS partial for the `chi-picker-group` component and integrates it into the main picker groups stylesheet. The changes focus on improving the styling and layout logic for grouped picker components, with special attention to border radius, padding, and responsive behavior, particularly when tooltips and fluid layouts are involved.

**Picker group component styling improvements:**

* Added a new `_picker-group-component.scss` partial that defines advanced layout and border logic for `chi-picker-group`, including correct border radius and padding for first, last, and middle items, overrides for legacy selector issues, and responsive adjustments for fluid layouts. The new styles also address tooltip integration and ensure consistent appearance across breakpoints.

**Integration and organization:**

* Imported the new `_picker-group-component.scss` partial into the main `picker-groups.scss` file to apply the new styles to the component.