### PR TITLE
[DPEDE-6956] Fix z index for global sidenav

### DIFF
--- a/src/chi/components/sidebar/sidenav.scss
+++ b/src/chi/components/sidebar/sidenav.scss
@@ -14,7 +14,6 @@ $sidenav-lg-width: 12.5rem;
     box-shadow: $sidenav-box-shadow;
     height: 100%;
     position: relative;
-    z-index: $zindex-fixed + 2;
 
     // sass-lint:disable-block no-universal-selectors
     > * + nav {
@@ -689,6 +688,7 @@ $sidenav-lg-width: 12.5rem;
       background-color: transparent;
       box-shadow: none;
       padding-top: 3rem;
+      z-index: $zindex-fixed + 2;
 
       & > nav {
         background-color: $sidenav-background-color;


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-6956

This pull request makes a minor adjustment to the `src/chi/components/sidebar/sidenav.scss` file, specifically relocating the `z-index` property for the sidebar component. The change moves the `z-index` assignment from the root sidebar selector to a more specific context, likely to improve stacking behavior and specificity.
