### PR TITLE
[DPEDE-7008] Add styles for close icon in text input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3153,17 +3153,6 @@
         }
       }
     },
-    "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@nuxt/cli/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",

--- a/src/chi/components/input-text/_input-wrapper.scss
+++ b/src/chi/components/input-text/_input-wrapper.scss
@@ -171,6 +171,55 @@ $sizes: (
   }
 
   &.-icon--right {
+    chi-button[type='close'] {
+      position: absolute;
+      right: $text-input-clearable-right;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    &.-clear-with-right-icon {
+      .chi-input {
+        padding-right: $text-input-md-clearable-with-icon-padding-right;
+
+        &.-xs {
+          padding-right: $text-input-xs-clearable-with-icon-padding-right;
+        }
+
+        &.-sm {
+          padding-right: $text-input-sm-clearable-with-icon-padding-right;
+        }
+
+        &.-md {
+          padding-right: $text-input-md-clearable-with-icon-padding-right;
+        }
+
+        &.-lg {
+          padding-right: $text-input-lg-clearable-with-icon-padding-right;
+        }
+
+        &.-xl {
+          padding-right: $text-input-xl-clearable-with-icon-padding-right;
+        }
+      }
+
+      chi-button[type='close'] {
+        right: $text-input-md-clearable-with-icon-right;
+      }
+
+      .chi-input.-xs ~ chi-button[type='close'] {
+        right: $text-input-xs-clearable-with-icon-right;
+      }
+
+      .chi-input.-sm ~ chi-button[type='close'] {
+        right: $text-input-sm-clearable-with-icon-right;
+      }
+
+      .chi-input.-xl ~ chi-button[type='close'] {
+        right: $text-input-xl-clearable-with-icon-right;
+      }
+    }
+
     input {
       &.chi-input {
         padding-right: $text-input-md-iconright-padding-right;

--- a/src/chi/templates/app-layout.scss
+++ b/src/chi/templates/app-layout.scss
@@ -137,6 +137,12 @@
     width: 100%;
   }
 
+  &__header-breadcrumb {
+    .chi-link {
+      font-weight: 500;
+    }
+  }
+
   &__header-content {
     display: flex;
     flex-direction: column;

--- a/src/chi/themes/brightspeed/_variables.scss
+++ b/src/chi/themes/brightspeed/_variables.scss
@@ -2561,6 +2561,17 @@ $text-input-xl-icon-width:                  1.5rem;
 $text-input-xl-icon-top:                    1rem;
 $text-input-xl-spinner-right:               1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom:       0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left:         0.75rem;

--- a/src/chi/themes/centurylink/_variables.scss
+++ b/src/chi/themes/centurylink/_variables.scss
@@ -2576,6 +2576,17 @@ $text-input-xl-icon-width:                  1.5rem;
 $text-input-xl-icon-top:                    1rem;
 $text-input-xl-spinner-right:               1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom:       0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left:         0.75rem;

--- a/src/chi/themes/colt/_variables.scss
+++ b/src/chi/themes/colt/_variables.scss
@@ -2574,6 +2574,17 @@ $text-input-xl-icon-width:                  1.5rem;
 $text-input-xl-icon-top:                    1rem;
 $text-input-xl-spinner-right:               1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom:       0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left:         0.75rem;

--- a/src/chi/themes/connect/_variables.scss
+++ b/src/chi/themes/connect/_variables.scss
@@ -2620,6 +2620,17 @@ $text-input-xl-icon-width: 1.5rem;
 $text-input-xl-icon-top: 1rem;
 $text-input-xl-spinner-right: 1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom: 0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left: 0.75rem;

--- a/src/chi/themes/lumen/_variables.scss
+++ b/src/chi/themes/lumen/_variables.scss
@@ -2602,6 +2602,17 @@ $text-input-xl-icon-width: 1.5rem;
 $text-input-xl-icon-top: 1rem;
 $text-input-xl-spinner-right: 1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom: 0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left: 0.75rem;

--- a/src/chi/themes/portal/_variables.scss
+++ b/src/chi/themes/portal/_variables.scss
@@ -2601,6 +2601,17 @@ $text-input-xl-icon-width: 1.5rem;
 $text-input-xl-icon-top: 1rem;
 $text-input-xl-spinner-right: 1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom: 0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left: 0.75rem;

--- a/src/chi/themes/test/_variables.scss
+++ b/src/chi/themes/test/_variables.scss
@@ -2685,6 +2685,17 @@ $text-input-xl-icon-width: 1.5rem;
 $text-input-xl-icon-top: 1.25rem;
 $text-input-xl-spinner-right: 1.25rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom: 0.75rem;
 $text-input-md-floating-label-focus-bottom: 1.1875rem;
 $text-input-md-floating-label-left: 0.75rem;


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7008

This pull request introduces improved support for clearable input text fields that also have a right-side icon, ensuring proper alignment and spacing across different input sizes and themes. It does so by adding new SCSS variables for spacing and padding, and updating the relevant styles to use these variables. Additionally, a minor style update is made to breadcrumb links in the app layout.

**Input Text Clearable with Right Icon Enhancements:**

* Added new SCSS variables for clearable input fields with right icons, including specific padding and right-position values for each input size, across all theme variable files (`_variables.scss`). [[1]](diffhunk://#diff-d4987eddbda158fe1eaecf7c9ebad97feee9b77aa3cba32363fa8e86d09d0db8R2564-R2574) [[2]](diffhunk://#diff-7b98587e70e09cb897a4d23dd1e4516faf7d1159debb584cc1bd9ddbd34dc115R2579-R2589) [[3]](diffhunk://#diff-22e26aa21bf38807f4abfcd51a1ac9ebaf916fa7783a644449f29abc15998688R2577-R2587) [[4]](diffhunk://#diff-b5fafe481b0c804a8a866ac71a02214f0bafdbbacb30b8d82a7b737f644fe3f2R2623-R2633) [[5]](diffhunk://#diff-495c919d9772d4e477a0a26ff0f130f61e7ac57d0fc3cc8ea6404b8145e4d8f3R2605-R2615) [[6]](diffhunk://#diff-4a9b7b911a2cccf68fdc1b8b09cfb3469b4f9be7de01db241d6ff8f12e2b7712R2604-R2614) [[7]](diffhunk://#diff-c476624e252bba6fc73a12fed4476c1aa613959d0fc053d4fa4702081ddefc96R2688-R2698)
* Updated `src/chi/components/input-text/_input-wrapper.scss` to use the new variables, ensuring correct positioning of the clear button and padding for input fields when both a clear button and a right icon are present, with responsive handling for all input sizes.

**App Layout Styling:**

* Increased the font weight of breadcrumb links in the app header for better visibility (`src/chi/templates/app-layout.scss`).