### PR TITLE
[DPEDE-7008] Add styles for close icon in text input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3153,17 +3153,6 @@
         }
       }
     },
-    "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@nuxt/cli/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3153,6 +3153,17 @@
         }
       }
     },
+    "node_modules/@nuxt/cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nuxt/cli/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",

--- a/src/chi/components/dropdown/dropdown.scss
+++ b/src/chi/components/dropdown/dropdown.scss
@@ -236,6 +236,10 @@ $_dropdown-sizes: (
       }
     }
 
+    &-items-wrapper {
+      overflow: auto;
+    }
+
     &.-active {
       display: block;
     }
@@ -310,6 +314,12 @@ $_dropdown-sizes: (
         margin: 0;
         word-break: break-word;
       }
+    }
+
+    & chi-search-input {
+      width: auto;
+      margin-left: 0.5rem;
+      margin-right: 0.5rem;
     }
 
     & > .chi-input__wrapper {
@@ -662,7 +672,7 @@ a.chi-dropdown__menu-item {
       font-size: map-get($md, select-chevron-size);
       width: 1rem;
     }
-    
+
     &:not(.-disabled) {
       &::after {
         color: $dropdown-select-chevron-color;

--- a/src/chi/components/input-text/_input-wrapper.scss
+++ b/src/chi/components/input-text/_input-wrapper.scss
@@ -46,6 +46,65 @@ $sizes: (
   )
 );
 
+@mixin input-right-padding-and-icon-position($md, $xs, $sm, $lg, $xl) {
+  padding-right: $md;
+
+  &.-xs {
+    padding-right: $xs;
+
+    & ~ .chi-icon,
+    & ~ chi-icon {
+      &:last-of-type {
+        right: $text-input-xs-iconright-right;
+      }
+    }
+  }
+
+  &.-sm {
+    padding-right: $sm;
+
+    & ~ .chi-icon,
+    & ~ chi-icon {
+      &:last-of-type {
+        right: $text-input-sm-iconright-right;
+      }
+    }
+  }
+
+  &.-md {
+    padding-right: $md;
+  }
+
+  &.-lg {
+    padding-right: $lg;
+
+    & ~ .chi-icon,
+    & ~ chi-icon {
+      &:last-of-type {
+        right: $text-input-lg-iconright-right;
+      }
+    }
+  }
+
+  &.-xl {
+    padding-right: $xl;
+
+    & ~ .chi-icon,
+    & ~ chi-icon {
+      &:last-of-type {
+        right: $text-input-xl-iconright-right;
+      }
+    }
+  }
+
+  & ~ .chi-icon,
+  & ~ chi-icon {
+    &:last-of-type {
+      right: $text-input-md-iconright-right;
+    }
+  }
+}
+
 .chi-input__wrapper {
   .chi-input {
     & ~ .chi-icon,
@@ -178,106 +237,48 @@ $sizes: (
       transform: translateY(-50%);
     }
 
-    &.-icon--right-wrapper {
-      .chi-input {
-        padding-right: $text-input-md-clearable-with-icon-padding-right;
-
-        &.-xs {
-          padding-right: $text-input-xs-clearable-with-icon-padding-right;
-        }
-
-        &.-sm {
-          padding-right: $text-input-sm-clearable-with-icon-padding-right;
-        }
-
-        &.-md {
-          padding-right: $text-input-md-clearable-with-icon-padding-right;
-        }
-
-        &.-lg {
-          padding-right: $text-input-lg-clearable-with-icon-padding-right;
-        }
-
-        &.-xl {
-          padding-right: $text-input-xl-clearable-with-icon-padding-right;
-        }
+    input {
+      &.chi-input {
+        @include input-right-padding-and-icon-position(
+          $text-input-md-iconright-padding-right,
+          $text-input-xs-iconright-padding-right,
+          $text-input-sm-iconright-padding-right,
+          $text-input-lg-iconright-padding-right,
+          $text-input-xl-iconright-padding-right
+        );
       }
+    }
+  }
 
-      chi-button[type='close'] {
-        right: $text-input-md-clearable-with-icon-right;
-      }
+  &.-icon--right-wrapper {
+    chi-button[type='close'] {
+      position: absolute;
+      right: $text-input-md-clearable-with-icon-right;
+      top: 50%;
+      transform: translateY(-50%);
+    }
 
-      .chi-input.-xs ~ chi-button[type='close'] {
-        right: $text-input-xs-clearable-with-icon-right;
-      }
+    .chi-input.-xs ~ chi-button[type='close'] {
+      right: $text-input-xs-clearable-with-icon-right;
+    }
 
-      .chi-input.-sm ~ chi-button[type='close'] {
-        right: $text-input-sm-clearable-with-icon-right;
-      }
+    .chi-input.-sm ~ chi-button[type='close'] {
+      right: $text-input-sm-clearable-with-icon-right;
+    }
 
-      .chi-input.-xl ~ chi-button[type='close'] {
-        right: $text-input-xl-clearable-with-icon-right;
-      }
+    .chi-input.-xl ~ chi-button[type='close'] {
+      right: $text-input-xl-clearable-with-icon-right;
     }
 
     input {
       &.chi-input {
-        padding-right: $text-input-md-iconright-padding-right;
-
-        &.-xs {
-          padding-right: $text-input-xs-iconright-padding-right;
-
-          & ~ .chi-icon,
-          & ~ chi-icon {
-            &:last-of-type {
-              right: $text-input-xs-iconright-right;
-            }
-          }
-        }
-
-        &.-sm {
-          padding-right: $text-input-sm-iconright-padding-right;
-
-          & ~ .chi-icon,
-          & ~ chi-icon {
-            &:last-of-type {
-              right: $text-input-sm-iconright-right;
-            }
-          }
-        }
-
-        &.-md {
-          padding-right: $text-input-md-iconright-padding-right;
-        }
-
-        &.-lg {
-          padding-right: $text-input-lg-iconright-padding-right;
-
-          & ~ .chi-icon,
-          & ~ chi-icon {
-            &:last-of-type {
-              right: $text-input-lg-iconright-right;
-            }
-          }
-        }
-
-        &.-xl {
-          padding-right: $text-input-xl-iconright-padding-right;
-
-          & ~ .chi-icon,
-          & ~ chi-icon {
-            &:last-of-type {
-              right: $text-input-xl-iconright-right;
-            }
-          }
-        }
-
-        & ~ .chi-icon,
-        & ~ chi-icon {
-          &:last-of-type {
-            right: $text-input-md-iconright-right;
-          }
-        }
+        @include input-right-padding-and-icon-position(
+          $text-input-md-clearable-with-icon-padding-right,
+          $text-input-xs-clearable-with-icon-padding-right,
+          $text-input-sm-clearable-with-icon-padding-right,
+          $text-input-lg-clearable-with-icon-padding-right,
+          $text-input-xl-clearable-with-icon-padding-right
+        );
       }
     }
   }

--- a/src/chi/components/input-text/_input-wrapper.scss
+++ b/src/chi/components/input-text/_input-wrapper.scss
@@ -171,6 +171,55 @@ $sizes: (
   }
 
   &.-icon--right {
+    chi-button[type='close'] {
+      position: absolute;
+      right: $text-input-clearable-right;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    &.-clear-with-right-icon {
+      .chi-input {
+        padding-right: $text-input-md-clearable-with-icon-padding-right;
+
+        &.-xs {
+          padding-right: $text-input-xs-clearable-with-icon-padding-right;
+        }
+
+        &.-sm {
+          padding-right: $text-input-sm-clearable-with-icon-padding-right;
+        }
+
+        &.-md {
+          padding-right: $text-input-md-clearable-with-icon-padding-right;
+        }
+
+        &.-lg {
+          padding-right: $text-input-lg-clearable-with-icon-padding-right;
+        }
+
+        &.-xl {
+          padding-right: $text-input-xl-clearable-with-icon-padding-right;
+        }
+      }
+
+      chi-button[type='close'] {
+        right: $text-input-md-clearable-with-icon-right;
+      }
+
+      .chi-input.-xs ~ chi-button[type='close'] {
+        right: $text-input-xs-clearable-with-icon-right;
+      }
+
+      .chi-input.-sm ~ chi-button[type='close'] {
+        right: $text-input-sm-clearable-with-icon-right;
+      }
+
+      .chi-input.-xl ~ chi-button[type='close'] {
+        right: $text-input-xl-clearable-with-icon-right;
+      }
+    }
+
     input {
       &.chi-input {
         padding-right: $text-input-md-iconright-padding-right;

--- a/src/chi/components/input-text/_input-wrapper.scss
+++ b/src/chi/components/input-text/_input-wrapper.scss
@@ -178,7 +178,7 @@ $sizes: (
       transform: translateY(-50%);
     }
 
-    &.-clear-with-right-icon {
+    &.-icon--right-wrapper {
       .chi-input {
         padding-right: $text-input-md-clearable-with-icon-padding-right;
 

--- a/src/chi/templates/app-layout.scss
+++ b/src/chi/templates/app-layout.scss
@@ -137,6 +137,12 @@
     width: 100%;
   }
 
+  &__header-breadcrumb {
+    .chi-link {
+      font-weight: 500;
+    }
+  }
+
   &__header-content {
     display: flex;
     flex-direction: column;

--- a/src/chi/templates/app-layout.scss
+++ b/src/chi/templates/app-layout.scss
@@ -139,7 +139,7 @@
 
   &__header-breadcrumb {
     .chi-link {
-      font-weight: 500;
+      font-weight: $font-weight-medium;
     }
   }
 

--- a/src/chi/themes/brightspeed/_variables.scss
+++ b/src/chi/themes/brightspeed/_variables.scss
@@ -28,6 +28,7 @@ $font-size-h1: 3rem; // 48px
 $font-weight-base: 400;
 $font-weight-light: 300;
 $font-weight-normal: 400;
+$font-weight-medium: 500;
 $font-weight-semi-bold: 600;
 $font-weight-bold: 700;
 $font-weight-extra-bold: 800;

--- a/src/chi/themes/brightspeed/_variables.scss
+++ b/src/chi/themes/brightspeed/_variables.scss
@@ -2561,6 +2561,17 @@ $text-input-xl-icon-width:                  1.5rem;
 $text-input-xl-icon-top:                    1rem;
 $text-input-xl-spinner-right:               1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom:       0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left:         0.75rem;

--- a/src/chi/themes/centurylink/_variables.scss
+++ b/src/chi/themes/centurylink/_variables.scss
@@ -2576,6 +2576,17 @@ $text-input-xl-icon-width:                  1.5rem;
 $text-input-xl-icon-top:                    1rem;
 $text-input-xl-spinner-right:               1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom:       0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left:         0.75rem;

--- a/src/chi/themes/centurylink/_variables.scss
+++ b/src/chi/themes/centurylink/_variables.scss
@@ -28,6 +28,7 @@ $font-size-h1: 3rem; // 48px
 $font-weight-base: 400;
 $font-weight-light: 300;
 $font-weight-normal: 400;
+$font-weight-medium: 500;
 $font-weight-semi-bold: 600;
 $font-weight-bold: 700;
 $font-weight-extra-bold: 800;

--- a/src/chi/themes/colt/_variables.scss
+++ b/src/chi/themes/colt/_variables.scss
@@ -2574,6 +2574,17 @@ $text-input-xl-icon-width:                  1.5rem;
 $text-input-xl-icon-top:                    1rem;
 $text-input-xl-spinner-right:               1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom:       0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left:         0.75rem;

--- a/src/chi/themes/colt/_variables.scss
+++ b/src/chi/themes/colt/_variables.scss
@@ -28,6 +28,7 @@ $font-size-h1: 3rem; // 48px
 $font-weight-base: 400;
 $font-weight-light: 300;
 $font-weight-normal: 400;
+$font-weight-medium: 500;
 $font-weight-semi-bold: 500;
 $font-weight-bold: 700;
 $font-weight-extra-bold: 800;

--- a/src/chi/themes/connect/_variables.scss
+++ b/src/chi/themes/connect/_variables.scss
@@ -2620,6 +2620,17 @@ $text-input-xl-icon-width: 1.5rem;
 $text-input-xl-icon-top: 1rem;
 $text-input-xl-spinner-right: 1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom: 0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left: 0.75rem;

--- a/src/chi/themes/lumen/_variables.scss
+++ b/src/chi/themes/lumen/_variables.scss
@@ -2602,6 +2602,17 @@ $text-input-xl-icon-width: 1.5rem;
 $text-input-xl-icon-top: 1rem;
 $text-input-xl-spinner-right: 1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom: 0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left: 0.75rem;

--- a/src/chi/themes/lumen/_variables.scss
+++ b/src/chi/themes/lumen/_variables.scss
@@ -28,6 +28,7 @@ $font-size-h1: 3rem; // 48px
 $font-weight-base: 400;
 $font-weight-light: 300;
 $font-weight-normal: 400;
+$font-weight-medium: 500;
 $font-weight-semi-bold: 500;
 $font-weight-bold: 700;
 $font-weight-extra-bold: 800;

--- a/src/chi/themes/portal/_variables.scss
+++ b/src/chi/themes/portal/_variables.scss
@@ -28,6 +28,7 @@ $font-size-h1: 3rem; // 48px
 $font-weight-base: 400;
 $font-weight-light: 300;
 $font-weight-normal: 400;
+$font-weight-medium: 500;
 $font-weight-semi-bold: 600;
 $font-weight-bold: 700;
 $font-weight-extra-bold: 800;

--- a/src/chi/themes/portal/_variables.scss
+++ b/src/chi/themes/portal/_variables.scss
@@ -2601,6 +2601,17 @@ $text-input-xl-icon-width: 1.5rem;
 $text-input-xl-icon-top: 1rem;
 $text-input-xl-spinner-right: 1rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom: 0.5rem;
 $text-input-md-floating-label-focus-bottom: 0.9375rem;
 $text-input-md-floating-label-left: 0.75rem;

--- a/src/chi/themes/test/_variables.scss
+++ b/src/chi/themes/test/_variables.scss
@@ -2685,6 +2685,17 @@ $text-input-xl-icon-width: 1.5rem;
 $text-input-xl-icon-top: 1.25rem;
 $text-input-xl-spinner-right: 1.25rem;
 
+$text-input-clearable-right:                      0.75rem;
+$text-input-xs-clearable-with-icon-padding-right: 2.9375rem;
+$text-input-sm-clearable-with-icon-padding-right: 3.1875rem;
+$text-input-md-clearable-with-icon-padding-right: 3.75rem;
+$text-input-lg-clearable-with-icon-padding-right: 3.75rem;
+$text-input-xl-clearable-with-icon-padding-right: 4.25rem;
+$text-input-xs-clearable-with-icon-right:         1.5rem;
+$text-input-sm-clearable-with-icon-right:         2rem;
+$text-input-md-clearable-with-icon-right:         2.5rem;
+$text-input-xl-clearable-with-icon-right:         2.875rem;
+
 $text-input-md-floating-label-bottom: 0.75rem;
 $text-input-md-floating-label-focus-bottom: 1.1875rem;
 $text-input-md-floating-label-left: 0.75rem;


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7008

This pull request introduces improvements to the styling and layout of input fields and header breadcrumbs across the application. The main focus is on enhancing the appearance and positioning of clearable input buttons (especially when used with right-aligned icons) and ensuring consistent spacing and alignment across different themes and input sizes. Additionally, the breadcrumb links in the app layout header now have a bolder font weight for better visibility.

**Input Field Styling and Theming Improvements:**

* Added new SCSS rules in `input-wrapper.scss` to properly position the clearable button (`chi-button[type='close']`) when an input has a right-aligned icon, including responsive padding and positioning adjustments for different input sizes (`-xs`, `-sm`, `-md`, `-lg`, `-xl`).
* Introduced new SCSS variables for clearable input button positioning and input padding for all supported themes, ensuring consistent look and feel across Brightspeed, CenturyLink, Colt, Connect, Lumen, Portal, and Test themes. [[1]](diffhunk://#diff-d4987eddbda158fe1eaecf7c9ebad97feee9b77aa3cba32363fa8e86d09d0db8R2564-R2574) [[2]](diffhunk://#diff-7b98587e70e09cb897a4d23dd1e4516faf7d1159debb584cc1bd9ddbd34dc115R2579-R2589) [[3]](diffhunk://#diff-22e26aa21bf38807f4abfcd51a1ac9ebaf916fa7783a644449f29abc15998688R2577-R2587) [[4]](diffhunk://#diff-b5fafe481b0c804a8a866ac71a02214f0bafdbbacb30b8d82a7b737f644fe3f2R2623-R2633) [[5]](diffhunk://#diff-495c919d9772d4e477a0a26ff0f130f61e7ac57d0fc3cc8ea6404b8145e4d8f3R2605-R2615) [[6]](diffhunk://#diff-4a9b7b911a2cccf68fdc1b8b09cfb3469b4f9be7de01db241d6ff8f12e2b7712R2604-R2614) [[7]](diffhunk://#diff-c476624e252bba6fc73a12fed4476c1aa613959d0fc053d4fa4702081ddefc96R2688-R2698)

**App Layout Header Enhancement:**

* Updated the breadcrumb styling in the app layout header so that breadcrumb links (`chi-link`) now use a font weight of 500, making them more prominent and easier to read.