### PR TITLE
[DPEDE-6425] Fix z index in draggable popover

### DIFF
--- a/src/chi/components/popover/popover.scss
+++ b/src/chi/components/popover/popover.scss
@@ -232,7 +232,8 @@
         position: absolute;
         right: 0.5rem;
         top: 0.5rem;
-
+        z-index: 1;
+        
         .chi-button {
           &.-close {
             right: 0;


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-6425

This pull request introduces a minor styling adjustment to the popover component. The change ensures that the close button within the popover is rendered above other elements by increasing its stacking context.

* Added `z-index: 1;` to the close button container in `popover.scss` to ensure it appears above overlapping elements.