### PR TITLE
[DPEDE-7055] Reduce app layout header margin and remove content padding

### DIFF
--- a/src/chi/templates/app-layout.scss
+++ b/src/chi/templates/app-layout.scss
@@ -259,18 +259,18 @@
       padding: 2rem 1rem;
 
       @include respond-to(sm) {
-        padding: 2.5rem 1.5rem;
+        padding: 2rem 1.5rem;
       }
 
       @include respond-to(md) {
         align-items: stretch;
         flex-direction: column;
         justify-content: flex-start;
-        padding: 2.5rem 2rem;
+        padding: 2rem 2rem;
       }
 
       @include respond-to(lg) {
-        padding: 2.5rem 4rem;
+        padding: 2rem 4rem;
       }
 
       .chi-main__header-start {
@@ -317,8 +317,6 @@
     }
 
     .chi-main__content {
-      padding-top: 2rem;
-
       .chi-main__accordion {
         > chi-accordion > .chi-accordion > .chi-accordion__item {
           background: transparent;


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7055

This pull request makes minor adjustments to the padding in the `app-layout.scss` file to improve layout consistency across different screen sizes. The changes reduce the overall padding and remove unnecessary top padding in the main content area.

Layout and spacing adjustments:

* Reduced padding for the main container at various breakpoints (`sm`, `md`, `lg`) to standardize spacing.
* Removed the `padding-top` from the `.chi-main__content` class to streamline vertical spacing.