### PR TITLE
[DPEDE-7111] Remove underline from icon in chi-link

### DIFF
--- a/src/chi/components/link/link.scss
+++ b/src/chi/components/link/link.scss
@@ -79,15 +79,39 @@ a,
     }
   }
 
+  &:has(.chi-icon) {
+    text-decoration: none;
+
+    &:hover,
+    &.-hover {
+      text-decoration: none;
+    }
+
+    &:not(.-no-underline):not(.-cta) {
+      > div > :not(chi-icon):not(.chi-icon),
+      > :not(chi-icon):not(.chi-icon):not(div) {
+        text-decoration: $link-text-decoration;
+      }
+    }
+
+    &:not(.-no-hover-underline):not(.-cta) {
+      &:hover,
+      &.-hover {
+        > div > :not(chi-icon):not(.chi-icon),
+        > :not(chi-icon):not(.chi-icon):not(div) {
+          text-decoration: $link-hover-text-decoration;
+        }
+      }
+    }
+  }
+
   .chi-link__content {
     align-items: center;
     display: flex;
 
-    & > i {
-      &.chi-icon {
-        &::before {
-          display: inline-block;
-        }
+    .chi-icon {
+      &::before {
+        display: inline-block;
       }
     }
 


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7111

This pull request updates the link component styles in `link.scss` to improve how underlining is handled for links containing icons. The main focus is to ensure that links with icons do not get underlined unnecessarily, while still allowing for underlining on other content when appropriate.

**Link underline behavior improvements:**

* Added a new rule so that links containing a `.chi-icon` do not show underlines by default, including on hover, unless specific modifier classes are present.
* Ensured that only non-icon content inside links gets underlined, respecting the `$link-text-decoration` and `$link-hover-text-decoration` variables, and allowing for opt-out with `.-no-underline` and `.-no-hover-underline` classes.

**Code simplification:**

* Simplified the selector for styling `.chi-icon` inside `.chi-link__content`, removing unnecessary nesting and targeting.