### PR TITLE
[DPEDE-7094] Improve bottom spacing in customize panel component add columns

### DIFF
--- a/src/chi/components/customize-panel/customize-panel.scss
+++ b/src/chi/components/customize-panel/customize-panel.scss
@@ -25,11 +25,6 @@
 
       &.chi-customize-panel__header-add {
         flex-direction: column;
-        padding-bottom: 0;
-
-        > span {
-          padding-bottom: $customize-panel-items-header-padding-bottom;
-        }
 
         > chi-link {
           margin-bottom: $customize-panel-back-link-margin-bottom;

--- a/src/chi/components/customize-panel/customize-panel.scss
+++ b/src/chi/components/customize-panel/customize-panel.scss
@@ -27,6 +27,10 @@
         flex-direction: column;
         padding-bottom: 0;
 
+        > span {
+          padding-bottom: $customize-panel-items-header-padding-bottom;
+        }
+
         > chi-link {
           margin-bottom: $customize-panel-back-link-margin-bottom;
           font-weight: $customize-panel-back-link-font-weight;


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7094

This pull request makes a minor styling adjustment to the `customize-panel` component. A new rule adds bottom padding to any direct `span` child within the panel, improving spacing and layout consistency.

* Added bottom padding to direct `span` children of the `customize-panel` for improved spacing.