### PR TITLE
[DPEDE-7139] Fix button and the search input alignment

### DIFF
--- a/src/chi/components/buttons/buttons.scss
+++ b/src/chi/components/buttons/buttons.scss
@@ -106,7 +106,6 @@ $sizes: (
   &__content {
     align-items: center;
     display: inline-flex;
-    gap: 0.5rem;
     justify-content: center;
     width: 100%;
   }

--- a/src/chi/components/input-text/_input-search.scss
+++ b/src/chi/components/input-text/_input-search.scss
@@ -33,6 +33,7 @@
       &.-close:not(.-disabled) {
         right: $search-input-md-close-right;
         top: $search-input-md-close-top;
+        transform: none;
 
         &:active {
           background-color: $search-input-icon-active-background-color;


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7139

This pull request makes minor style adjustments to the button and search input components. The most notable changes are the removal of the gap between button content elements and the addition of a transform reset for the close icon in search inputs.

**Button styles:**

* Removed the `gap` property from the `__content` class in `buttons.scss`, which eliminates the spacing between inline-flex button content elements.

**Input search styles:**

* Added `transform: none;` to the close icon in `input-search.scss` to ensure it doesn't inherit unwanted transforms.