### PR TITLE
[DPEDE-7142] Fix the underline of links in sidenav

### DIFF
--- a/src/chi/_global-mixins.scss
+++ b/src/chi/_global-mixins.scss
@@ -75,3 +75,25 @@
     @content;
   }
 }
+
+@mixin link-icon-text-children {
+  > div > :not(chi-icon):not(.chi-icon),
+  > :not(chi-icon):not(.chi-icon):not(div) {
+    @content;
+  }
+}
+
+@mixin nav-link-icon-no-underline {
+  &:has(.chi-icon) {
+    @include link-icon-text-children {
+      text-decoration: none;
+    }
+
+    &:hover,
+    &.-hover {
+      @include link-icon-text-children {
+        text-decoration: none;
+      }
+    }
+  }
+}

--- a/src/chi/components/buttons/buttons.scss
+++ b/src/chi/components/buttons/buttons.scss
@@ -106,6 +106,7 @@ $sizes: (
   &__content {
     align-items: center;
     display: inline-flex;
+    gap: 0.5rem;
     justify-content: center;
     width: 100%;
   }

--- a/src/chi/components/link/link.scss
+++ b/src/chi/components/link/link.scss
@@ -88,8 +88,7 @@ a,
     }
 
     &:not(.-no-underline):not(.-cta) {
-      > div > :not(chi-icon):not(.chi-icon),
-      > :not(chi-icon):not(.chi-icon):not(div) {
+      @include link-icon-text-children {
         text-decoration: $link-text-decoration;
       }
     }
@@ -97,8 +96,7 @@ a,
     &:not(.-no-hover-underline):not(.-cta) {
       &:hover,
       &.-hover {
-        > div > :not(chi-icon):not(.chi-icon),
-        > :not(chi-icon):not(.chi-icon):not(div) {
+        @include link-icon-text-children {
           text-decoration: $link-hover-text-decoration;
         }
       }

--- a/src/chi/components/mobile-navigation/mobile-navigation.scss
+++ b/src/chi/components/mobile-navigation/mobile-navigation.scss
@@ -712,6 +712,21 @@
           &:hover {
             background: $mobile-nav-list-item-hover-background-color;
           }
+
+          &:has(.chi-icon) {
+            > div > :not(chi-icon):not(.chi-icon),
+            > :not(chi-icon):not(.chi-icon):not(div) {
+              text-decoration: none;
+            }
+
+            &:hover,
+            &.-hover {
+              > div > :not(chi-icon):not(.chi-icon),
+              > :not(chi-icon):not(.chi-icon):not(div) {
+                text-decoration: none;
+              }
+            }
+          }
         }
 
         .chi-mobile-nav__email {

--- a/src/chi/components/mobile-navigation/mobile-navigation.scss
+++ b/src/chi/components/mobile-navigation/mobile-navigation.scss
@@ -713,20 +713,7 @@
             background: $mobile-nav-list-item-hover-background-color;
           }
 
-          &:has(.chi-icon) {
-            > div > :not(chi-icon):not(.chi-icon),
-            > :not(chi-icon):not(.chi-icon):not(div) {
-              text-decoration: none;
-            }
-
-            &:hover,
-            &.-hover {
-              > div > :not(chi-icon):not(.chi-icon),
-              > :not(chi-icon):not(.chi-icon):not(div) {
-                text-decoration: none;
-              }
-            }
-          }
+          @include nav-link-icon-no-underline;
         }
 
         .chi-mobile-nav__email {

--- a/src/chi/components/sidebar/sidenav.scss
+++ b/src/chi/components/sidebar/sidenav.scss
@@ -895,6 +895,21 @@ $sidenav-lg-width: 12.5rem;
               color: $sidenav-global-item-text-color;
               font-size: $sidenav-global-item-font-size;
               text-decoration: none;
+
+              &:has(.chi-icon) {
+                > div > :not(chi-icon):not(.chi-icon),
+                > :not(chi-icon):not(.chi-icon):not(div) {
+                  text-decoration: none;
+                }
+
+                &:hover,
+                &.-hover {
+                  > div > :not(chi-icon):not(.chi-icon),
+                  > :not(chi-icon):not(.chi-icon):not(div) {
+                    text-decoration: none;
+                  }
+                }
+              }
             }
 
             .chi-sidenav__item-wrapper:has(chi-accordion) {

--- a/src/chi/components/sidebar/sidenav.scss
+++ b/src/chi/components/sidebar/sidenav.scss
@@ -896,20 +896,7 @@ $sidenav-lg-width: 12.5rem;
               font-size: $sidenav-global-item-font-size;
               text-decoration: none;
 
-              &:has(.chi-icon) {
-                > div > :not(chi-icon):not(.chi-icon),
-                > :not(chi-icon):not(.chi-icon):not(div) {
-                  text-decoration: none;
-                }
-
-                &:hover,
-                &.-hover {
-                  > div > :not(chi-icon):not(.chi-icon),
-                  > :not(chi-icon):not(.chi-icon):not(div) {
-                    text-decoration: none;
-                  }
-                }
-              }
+              @include nav-link-icon-no-underline;
             }
 
             .chi-sidenav__item-wrapper:has(chi-accordion) {


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7142

This pull request introduces new SCSS mixins for improved link and navigation styling, and applies them to ensure consistent behavior for links with icons across the codebase. It also adds spacing between button content elements for better visual alignment.

**Link and Navigation Styling Improvements:**
* Added the `link-icon-text-children` and `nav-link-icon-no-underline` mixins to `_global-mixins.scss` to encapsulate logic for handling text-decoration on links containing icons.
* Refactored `link.scss` to use the new `link-icon-text-children` mixin, simplifying and centralizing the logic for underlining text in links with icons.
* Applied the `nav-link-icon-no-underline` mixin to navigation links in `mobile-navigation.scss` and `sidenav.scss`, ensuring that text adjacent to icons in navigation links does not get underlined. [[1]](diffhunk://#diff-43d33665016c4c1dd385f71919703d352594d2b65e785cd678b27671ff61d823R715-R716) [[2]](diffhunk://#diff-d2ba2293bde4ae80c9c56a26c79790fbd84b9b3093778506fec73d0fc76d11b3R898-R899)

**Button Layout Enhancement:**
* Added a `gap: 0.5rem;` to the `__content` class in `buttons.scss` for improved spacing between button children elements.