### PR TITLE
[DPEDE-7065] Improve btn alignment in data table

### DIFF
--- a/src/chi/components/data-table/data-table.scss
+++ b/src/chi/components/data-table/data-table.scss
@@ -1124,27 +1124,16 @@ $sizes: (
           padding-left: 2rem;
 
           &.-expandable {
-            display: block;
+            display: flex;
             overflow: initial;
             position: relative;
 
             .chi-button {
               &.-expand {
-                display: block;
-                left: -0.125rem;
-                position: absolute;
-                top: -0.0625rem;
                 z-index: 1;
 
                 &.-flat {
                   border-width: 0.0625rem;
-                }
-
-                @include respond-to(md) {
-                  left: 0;
-                  position: relative;
-                  top: 0;
-                  z-index: auto;
                 }
               }
             }

--- a/src/chi/components/data-table/data-table.scss
+++ b/src/chi/components/data-table/data-table.scss
@@ -522,7 +522,6 @@ $sizes: (
             &.-flat {
               position: absolute;
               right: 1.375rem;
-              top: -1.25rem;
             }
           }
         }
@@ -1124,16 +1123,32 @@ $sizes: (
           padding-left: 2rem;
 
           &.-expandable {
-            display: flex;
+            display: block;
             overflow: initial;
             position: relative;
 
+            @include respond-to(md) {
+              display: flex;
+            }
+
             .chi-button {
               &.-expand {
+                display: block;
+                left: -0.125rem;
+                position: absolute;
+                top: -0.0625rem;
                 z-index: 1;
 
                 &.-flat {
                   border-width: 0.0625rem;
+                }
+
+                @include respond-to(md) {
+                  display: flex;
+                  left: 0;
+                  position: relative;
+                  top: 0;
+                  z-index: auto;
                 }
               }
             }


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7065

This pull request updates the styling for expandable rows in the data table component, specifically improving the layout and button positioning for better consistency and flexibility.

**Data table layout and button styling:**

* Changed the expandable row container from `display: block` to `display: flex` for improved layout handling (`src/chi/components/data-table/data-table.scss`).
* Simplified the `.chi-button.-expand` styling by removing absolute positioning and media query overrides, relying on the new flex layout for alignment (`src/chi/components/data-table/data-table.scss`).