### PR TITLE
[DPEDE-7155] Enhance icons in chi.js for slow connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+Chi (`@centurylink/chi`) is Lumen's design system: multi-theme CSS + vanilla-JS components, built with Sass and Vite. There is no framework runtime — output is plain `chi.css` + `chi.js` consumed via CDN, with companion packages for Web Components and Vue.
+
+## Commands
+
+```bash
+npm install                 # Node 20+
+npm run start               # static server (serve.cjs) + Vite dev together
+npm run start:local         # Vite dev only (HMR), http://localhost:5173
+
+npm run build               # full prod-style build, all themes → dist/
+# faster local build (skips sibling-package copies that need them installed):
+SKIP_BOILERPLATES=1 SKIP_CHI_DOCUMENTATION=1 SKIP_SRI=1 npm run build
+
+# JS-only rebuild (seconds) — bundles src/chi/javascript/index.js:
+npx cross-env JS=iife vite build --c vite-js.config.ts   # → dist/js/chi.js
+npx cross-env JS=amd  vite build --c vite-js.config.ts   # → dist/amd/chi.js
+
+npm run lint:scss                       # sass-lint (config: .sass-lint.yml)
+npx sass-lint -v -q "src/path/file.scss"  # lint one file
+
+npm run cy:open                         # Cypress interactive
+npm run cy:run                          # Cypress headless (electron)
+# single spec:
+npx cypress run --config-file cypress.config.cjs --spec cypress/e2e/chi-js/icon.cy.js
+
+npm run tests:visual                    # BackstopJS visual regression (Docker)
+npm run tests:visual:approve            # accept new visual references
+
+npm run generate:ai-rules               # sync .cursor rules/skills from SCSS
+npm run build:mcp                       # regenerate src/mcp/metadata.json
+```
+
+`npm link` exposes a `chi` bin so the README's `chi start` / `chi build` / `chi test` are aliases for the npm scripts above.
+
+There is **no JS linter/formatter configured** in the repo (only `sass-lint` for styles). An editor may auto-format JS on save.
+
+## Architecture
+
+**Two independent build pipelines from one source tree**, orchestrated by `scripts/build/build.sh`:
+
+1. **CSS** — `scripts/build/css/build.js` loops the `THEMES_TO_BUILD` env list and invokes `vite-css.config.ts` once per theme (with the `THEME` env var set to that theme). `lumen` outputs `dist/chi.css`; every other theme outputs `dist/chi-<theme>.css`. PostCSS handles autoprefixing, SVG inlining, and cssnano. Theme sources live in `src/chi/themes/` — currently `brightspeed`, `centurylink`, `colt`, `connect`, `lumen`, `portal`, plus `test`; the default `npm run build` builds the `lumen,connect,centurylink,test` subset.
+2. **JS** — `vite-js.config.ts` bundles `src/chi/javascript/index.js` into a single file twice: IIFE (`dist/js/chi.js`) and AMD (`dist/amd/chi.js`), both minified. Adding a component = create the module, then export it from `index.js`; no config change.
+
+`build.sh` also copies prebuilt assets from sibling npm packages into `dist/`: `@centurylink/chi-documentation` (docs site), `@centurylink/chi-custom-elements` (Web Components, under `dist/js/ce`), `@centurylink/chi-vue`. It then builds boilerplates, test HTML, MCP metadata, and SRI hashes. The `SKIP_*` env vars short-circuit the slow/optional steps.
+
+**Themes** — `src/chi/themes/<theme>/index.scss` is the per-theme entry that `@import`s every component, utility, and skeleton. Theme `_variables.scss` override `src/chi`'s global defaults via Sass import order.
+
+**Vanilla-JS components** (`src/chi/javascript/`):
+- `core/component.js` — `Component` base class. Subclasses define `componentType` + `componentSelector` and get a **cached factory** (`Component.factory.bind(Class)`): one instance per element, stored on the element via `chi.expando` (see `core/util.js` data registry).
+- `core/util.js` — DOM/class helpers (`addClass`/`removeClass`/`hasClass`), measurement, the component registry. Prefer these over re-implementing.
+- `index.js` — imports every component, re-exports `{Class, factory}` pairs, and attaches them all to `window.chi` (e.g. `chi.dropdown(el)`, `new chi.Dropdown(el)`).
+- Most components require explicit init by the consumer (`chi.dropdown(el)`); the icon module is the exception — it self-initializes on load (scans `.chi-icon` + a `MutationObserver`) so HTML icons are enhanced without any author call.
+
+**Icons** — Material Symbols Outlined webfont. HTML usage is class-based: `<i class="chi-icon icon-<name>">`, where `icon-mapping.scss` generates `::before { content: '<ligature>' }` for each mapped name (logos use `mask-image` instead). `icon-*` classes that aren't in the mapping render nothing. The `chi-icon` Web Component (in the chi-custom-elements sibling repo, not here) is the richer version; the HTML/CSS icons here are font + JS only.
+
+**Tests** — Cypress JS specs (`cypress/e2e/chi-js/*.cy.js`) run against **built static HTML**, not src. Fixtures are Pug (`tests/js/*.pug`, extending `tests/layout.pug`) compiled by `scripts/build/utils/buildTests.js` into `dist/tests/<theme>/js/*.html` and served. `THEMES_TO_TEST` (from `scripts/tests/backstopConfig.sh`, default `lumen`) selects the theme. So: edit a `.pug` fixture → re-run `buildTests.js` → serve `dist` → run Cypress. Visual regression is BackstopJS in Docker.
+
+**MCP / AI assets** — `src/mcp/` generates `metadata.json` (tokens, utilities, components, schemas) and the `.cursor/` rules & skills, derived from the SCSS sources. See `.github/copilot-instructions.md` and `src/mcp/README.md` for the rules/skills catalog and conventions (double-dash utility syntax, BEM, theming).
+
+## Conventions
+
+- **Commits & PRs** use `[DPEDE-XXXX] <Jira ticket title>` (the Jira project key), **not** Conventional Commits.
+- Production consumers load `chi.css` from `https://lib.lumen.com/chi/<VERSION>/` and must put `class="chi"` on `<html>` to scope the styles.
+- `dist/` is build output and git-ignored — never edit it by hand; rebuild instead.

--- a/cypress/e2e/chi-js/icon.cy.js
+++ b/cypress/e2e/chi-js/icon.cy.js
@@ -1,0 +1,55 @@
+describe('Icon', () => {
+  before(() => {
+    cy.visit('tests/lumen/js/icon.html');
+  });
+
+  const VALID_ICON = '#valid-icon';
+  const INVALID_ICON = '#invalid-icon';
+  const LOGO_ICON = '#logo-icon';
+  const ADD_ICON_BTN = '#add-icon-button';
+  const DYNAMIC_ICON = '#dynamic-icon';
+  const LOADING_CLASS = '-loading';
+  const HIDDEN_CLASS = '-d--none';
+
+  beforeEach(() => {
+    cy.reload();
+    cy.get(VALID_ICON).as('validIcon');
+    cy.get(INVALID_ICON).as('invalidIcon');
+    cy.get(LOGO_ICON).as('logoIcon');
+    // Wait for the icon font to finish loading so the loading state settles.
+    cy.document().then((doc) => doc.fonts && doc.fonts.ready);
+  });
+
+  // The fixture never calls chi.icon(): loading chi.js auto-enhances the page.
+  it('hides an icon with an invalid name automatically', () => {
+    cy.get('@invalidIcon').should('have.class', HIDDEN_CLASS);
+  });
+
+  it('leaves a valid icon visible and not hidden', () => {
+    cy.get('@validIcon').should('not.have.class', HIDDEN_CLASS);
+    cy.get('@validIcon').should('be.visible');
+  });
+
+  it('does not skeleton or hide a logo (css-mask) icon', () => {
+    cy.get('@logoIcon').should('not.have.class', HIDDEN_CLASS);
+    cy.get('@logoIcon').should('not.have.class', LOADING_CLASS);
+  });
+
+  it('keeps a valid ligature icon visible', () => {
+    cy.get('#valid-ligature').should('not.have.class', HIDDEN_CLASS);
+  });
+
+  it('hides a ligature icon whose name does not resolve', () => {
+    cy.get('#invalid-ligature').should('have.class', HIDDEN_CLASS);
+  });
+
+  it('removes the loading class once the font is ready', () => {
+    cy.get('@validIcon').should('not.have.class', LOADING_CLASS);
+  });
+
+  it('enhances icons added to the DOM after load (MutationObserver)', () => {
+    cy.get(ADD_ICON_BTN).click();
+    cy.get(DYNAMIC_ICON).should('exist');
+    cy.get(DYNAMIC_ICON).should('not.have.class', HIDDEN_CLASS);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
     <title>Chi CSS & JS</title>
   </head>
   <body style="height: 100vh">
+    <i class="chi-icon">category</i>
+
     <style type="text/css">
       /* ── Layout ─────────────────────────────────────────────── */
 
@@ -113,9 +115,9 @@
         margin-bottom: 0.5rem;
       }
 
-      .chi-skeleton {
+      /* .chi-skeleton {
         height: 800px !important;
-      }
+      } */
 
       .shell-dependencies {
         z-index: 99999;

--- a/src/chi/javascript/components/icon.js
+++ b/src/chi/javascript/components/icon.js
@@ -1,0 +1,215 @@
+import { Util } from '../core/util.js';
+import { chi } from '../core/chi.js';
+
+const ICON_SELECTOR = '.chi-icon';
+const LOADING_CLASS = '-loading';
+const HIDDEN_CLASS = chi.classes.DISPLAY.NONE;
+const ICON_FONT = '1em "Material Symbols Outlined"';
+const NAMED_ICON = /(^|\s)icon-[\w-]+/;
+const LOGO_ICON = /(^|\s)icon-logo-/;
+const STYLE_RETRY_FRAMES = 300;
+const LIGATURE_GLYPH_RATIO = 1.4;
+
+let fontReady = false;
+let fontLoaded = false;
+let fontWatched = false;
+let retryRunning = false;
+let sawUnstyled = false;
+let observer = null;
+
+const forEach = Function.prototype.call.bind(Array.prototype.forEach);
+
+function computed(el, pseudo) {
+  return window.getComputedStyle(el, pseudo || null);
+}
+
+function isChiStyled(el) {
+  try {
+    return computed(el).fontFamily.indexOf('Material Symbols') !== -1;
+  } catch (e) {
+    return true;
+  }
+}
+
+function hasGlyph(el) {
+  try {
+    const glyph = computed(el, '::before').content;
+
+    return !!glyph && glyph !== 'none' && glyph !== 'normal';
+  } catch (e) {
+    return true;
+  }
+}
+
+function hasText(el) {
+  return !!(el.textContent && el.textContent.trim());
+}
+
+function isUnresolvedLigature(el) {
+  try {
+    const range = document.createRange();
+
+    range.selectNodeContents(el);
+
+    const width = range.getBoundingClientRect().width;
+    const fontSize = parseFloat(computed(el).fontSize) || 0;
+
+    return fontSize > 0 && width > fontSize * LIGATURE_GLYPH_RATIO;
+  } catch (e) {
+    return false;
+  }
+}
+
+function skip(el, classes) {
+  return !!((el.closest && el.closest('chi-icon')) || LOGO_ICON.test(classes));
+}
+
+function watchFont() {
+  if (fontWatched) {
+    return;
+  }
+  fontWatched = true;
+
+  const fonts = typeof document !== 'undefined' && document.fonts;
+
+  if (!fonts || typeof fonts.load !== 'function') {
+    fontReady = true;
+    fontLoaded = true;
+    return;
+  }
+
+  try {
+    if (fonts.check(ICON_FONT)) {
+      fontReady = true;
+    }
+  } catch (e) {
+    fontReady = true;
+  }
+
+  const onLoaded = () => {
+    fontReady = true;
+    fontLoaded = true;
+    enhanceAll();
+  };
+
+  fonts.load(ICON_FONT).then(onLoaded, onLoaded);
+}
+
+function enhanceIcon(el) {
+  const classes = el.className || '';
+
+  if (skip(el, classes)) {
+    return;
+  }
+
+  if (!isChiStyled(el)) {
+    sawUnstyled = true;
+    scheduleRetry();
+    return;
+  }
+
+  if (NAMED_ICON.test(classes) && !hasGlyph(el) && !hasText(el)) {
+    Util.addClass(el, HIDDEN_CLASS);
+    return;
+  }
+
+  watchFont();
+
+  if (!fontReady) {
+    Util.addClass(el, LOADING_CLASS);
+    return;
+  }
+
+  Util.removeClass(el, LOADING_CLASS);
+
+  if (fontLoaded && !hasGlyph(el) && hasText(el) && isUnresolvedLigature(el)) {
+    Util.addClass(el, HIDDEN_CLASS);
+  }
+}
+
+function enhanceAll() {
+  if (typeof document !== 'undefined') {
+    forEach(document.querySelectorAll(ICON_SELECTOR), enhanceIcon);
+  }
+}
+
+function scheduleRetry() {
+  if (retryRunning || typeof requestAnimationFrame === 'undefined') {
+    return;
+  }
+
+  retryRunning = true;
+
+  let frames = 0;
+  const tick = () => {
+    sawUnstyled = false;
+    enhanceAll();
+
+    if (sawUnstyled && ++frames < STYLE_RETRY_FRAMES) {
+      requestAnimationFrame(tick);
+    } else {
+      retryRunning = false;
+    }
+  };
+
+  requestAnimationFrame(tick);
+}
+
+function factory(target) {
+  if (!target) {
+    return;
+  }
+
+  if (target.nodeType === 1) {
+    enhanceIcon(target);
+  } else if (typeof target.length === 'number') {
+    forEach(target, factory);
+  }
+}
+
+function observe() {
+  if (observer || typeof MutationObserver === 'undefined' || !document.body) {
+    return;
+  }
+
+  observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      forEach(mutation.addedNodes, (node) => {
+        if (node.nodeType !== 1) {
+          return;
+        }
+
+        if (node.matches && node.matches(ICON_SELECTOR)) {
+          enhanceIcon(node);
+        }
+
+        if (node.querySelectorAll) {
+          factory(node.querySelectorAll(ICON_SELECTOR));
+        }
+      });
+    });
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+}
+
+function autoInit() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  enhanceAll();
+  observe();
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', autoInit);
+  } else {
+    autoInit();
+  }
+}
+
+const Icon = { initAll: enhanceAll };
+
+export { Icon, factory, autoInit };

--- a/src/chi/javascript/index.js
+++ b/src/chi/javascript/index.js
@@ -8,6 +8,7 @@ import { Dropdown, factory as dropdown } from './components/dropdown';
 import { ExpansionPanel, factory as expansionPanel, EXPANSION_PANEL_STATES } from "./components/expansion-panel";
 import { FloatingLabel, factory as floatingLabel } from "./components/floating-label";
 import { GlobalMobileNav, factory as globalMobileNav } from "./components/global-mobile-navigation";
+import { Icon, factory as icon } from "./components/icon";
 import { MobileNav, factory as mobilenav } from "./components/mobile-navigation";
 import { Modal, factory as modal } from './components/modal';
 import { Navigation, factory as navigation } from "./components/navigation";
@@ -30,6 +31,7 @@ export {
   expansionPanel,
   floatingLabel,
   globalMobileNav,
+  icon,
   mobilenav,
   modal,
   navigation,
@@ -48,6 +50,7 @@ export {
   ExpansionPanel,
   FloatingLabel,
   GlobalMobileNav,
+  Icon,
   MobileNav,
   Modal,
   Navigation,
@@ -73,6 +76,7 @@ if (typeof window !== 'undefined') {
     expansionPanel,
     floatingLabel,
     globalMobileNav,
+    icon,
     mobilenav,
     modal,
     navigation,
@@ -90,6 +94,7 @@ if (typeof window !== 'undefined') {
     ExpansionPanel,
     FloatingLabel,
     GlobalMobileNav,
+    Icon,
     MobileNav,
     Modal,
     Navigation,

--- a/src/chi/skeletons/icon.scss
+++ b/src/chi/skeletons/icon.scss
@@ -11,7 +11,8 @@ $sizes: (
   'xxl': 8rem,
 );
 
-chi-icon:not(.hydrated) {
+chi-icon:not(.hydrated),
+.chi-icon.-loading {
   animation: shine $animation-duration infinite linear;
   border-radius: 0.5rem;
   display: block;
@@ -32,25 +33,8 @@ chi-icon:not(.hydrated) {
 
 .chi-icon {
   &.-loading {
-    animation: shine $animation-duration infinite linear;
-    border-radius: 0.5rem;
-    display: inline-block;
-    font-size: 0;
-    height: 1rem;
-    width: 1rem;
-
     &::before {
       display: none;
     }
-
-    @each $size, $width in $sizes {
-      &.-#{$size} {
-        border-radius: $width / 2;
-        height: $width;
-        width: $width;
-      }
-    }
-
-    @include background-gradient;
   }
 }

--- a/src/chi/skeletons/icon.scss
+++ b/src/chi/skeletons/icon.scss
@@ -8,7 +8,8 @@ $sizes: (
   'md': 2rem,
   'lg': 4rem,
   'xl': 6rem,
-  'xxl': 8rem);
+  'xxl': 8rem,
+);
 
 chi-icon:not(.hydrated) {
   animation: shine $animation-duration infinite linear;
@@ -19,7 +20,7 @@ chi-icon:not(.hydrated) {
   width: 1rem;
 
   @each $size, $width in $sizes {
-    &[size=#{$size}] {
+    &[size='#{$size}'] {
       border-radius: $width / 2;
       height: $width;
       width: $width;
@@ -27,4 +28,29 @@ chi-icon:not(.hydrated) {
   }
 
   @include background-gradient;
+}
+
+.chi-icon {
+  &.-loading {
+    animation: shine $animation-duration infinite linear;
+    border-radius: 0.5rem;
+    display: inline-block;
+    font-size: 0;
+    height: 1rem;
+    width: 1rem;
+
+    &::before {
+      display: none;
+    }
+
+    @each $size, $width in $sizes {
+      &.-#{$size} {
+        border-radius: $width / 2;
+        height: $width;
+        width: $width;
+      }
+    }
+
+    @include background-gradient;
+  }
 }

--- a/tests/js/icon.pug
+++ b/tests/js/icon.pug
@@ -1,0 +1,31 @@
+extends ../layout.pug
+
+block scripts
+  script(src='../../../js/chi.js')
+  script(src='../../../chi-marketing-icons.js')
+
+block variables
+  - var title = 'Icon'
+
+block content
+  i#valid-icon.chi-icon.icon-circle-check.-lg(aria-hidden="true")
+  i#invalid-icon.chi-icon.icon-does-not-exist.-lg(aria-hidden="true")
+  i#logo-icon.chi-icon.icon-logo-aws.-lg(aria-hidden="true")
+  i#valid-ligature.chi-icon.-lg(aria-hidden="true") home
+  i#invalid-ligature.chi-icon.-lg(aria-hidden="true") notarealicon
+
+  button#add-icon-button.chi-button.-ml--3
+    | Add icon
+
+  #dynamic-container.-mt--3
+
+  script.
+    document.getElementById('add-icon-button').addEventListener('click', () => {
+      const i = document.createElement('i');
+      
+      i.id = 'dynamic-icon';
+      i.className = 'chi-icon icon-arrow-right -lg';
+      i.setAttribute('aria-hidden', 'true');
+      
+      document.getElementById('dynamic-container').appendChild(i);
+    });


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7155

This pull request introduces a comprehensive, self-initializing JavaScript enhancement for HTML-based icons in Chi, along with supporting tests, documentation, and style updates. The new `Icon` component automatically manages icon visibility, loading state, and error handling for both static and dynamically added icons, ensuring consistent behavior and improved developer experience.

**Major features and improvements:**

### Icon JavaScript Component

* Added a new `icon.js` module that auto-enhances `.chi-icon` elements: it hides invalid icons, applies a loading skeleton until the icon font is ready, and supports live enhancement of icons added after page load via a `MutationObserver`. The component handles ligature and logo icons, and exposes an `Icon` API for manual control if needed. (`src/chi/javascript/components/icon.js`)
* Integrated the new `Icon` component into the main Chi JS bundle and global namespace, making it available as `chi.icon` and `chi.Icon`. (`src/chi/javascript/index.js`) [[1]](diffhunk://#diff-d09d6540f06a868696ea8040d466bbdc2ea01f83c8ee12dd4939f79bd7392ca4R11) [[2]](diffhunk://#diff-d09d6540f06a868696ea8040d466bbdc2ea01f83c8ee12dd4939f79bd7392ca4R34) [[3]](diffhunk://#diff-d09d6540f06a868696ea8040d466bbdc2ea01f83c8ee12dd4939f79bd7392ca4R53) [[4]](diffhunk://#diff-d09d6540f06a868696ea8040d466bbdc2ea01f83c8ee12dd4939f79bd7392ca4R79) [[5]](diffhunk://#diff-d09d6540f06a868696ea8040d466bbdc2ea01f83c8ee12dd4939f79bd7392ca4R97)

### Testing

* Added a comprehensive Cypress test suite for the icon behavior, covering invalid/valid icons, logos, ligature handling, loading state, and dynamic DOM insertion. (`cypress/e2e/chi-js/icon.cy.js`)
* Created a new Pug fixture for icon tests, including test cases for all relevant icon types and dynamic addition. (`tests/js/icon.pug`)

### Styles

* Updated the icon skeleton styles to support the new loading state (`.-loading`), ensuring a consistent shimmer effect and sizing across icon variants. Also fixed attribute selector quoting for better Sass compatibility. (`src/chi/skeletons/icon.scss`) [[1]](diffhunk://#diff-0b8af3f3ffea798bb4011c88ff5ae8ed1859ab448e9944821fdfb90595b3345cL11-R12) [[2]](diffhunk://#diff-0b8af3f3ffea798bb4011c88ff5ae8ed1859ab448e9944821fdfb90595b3345cL22-R23) [[3]](diffhunk://#diff-0b8af3f3ffea798bb4011c88ff5ae8ed1859ab448e9944821fdfb90595b3345cR32-R56)

### Documentation

* Added a `CLAUDE.md` file documenting Chi's architecture, build commands, conventions, and the philosophy behind the design system, providing helpful context for contributors and AI tools. (`CLAUDE.md`)