### PR TITLE
[DPEDE-7205] Add styles for icon title in card component

### DIFF
--- a/src/chi/components/card/card.scss
+++ b/src/chi/components/card/card.scss
@@ -170,8 +170,11 @@
   }
 
   &__title {
+    align-items: center;
+    display: flex;
     font-size: $card-title-font-size;
     font-weight: $card-title-font-weight;
+    gap: 0.5rem;
     line-height: $card-title-line-height;
   }
 


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7205

This pull request updates the styling of the card component's title to improve its layout and alignment. The most important change is the addition of flexbox properties to the `card__title` class, which ensures better vertical alignment and spacing of its contents.

Card component styling improvements:

* Added `display: flex`, `align-items: center`, and `gap: 0.5rem` to the `card__title` class in `card.scss` to enhance alignment and spacing of title contents.