### PR TITLE
[DPEDE-7207] Fix dropdown menu items underline icon

### DIFF
--- a/src/chi/components/link/link.scss
+++ b/src/chi/components/link/link.scss
@@ -87,13 +87,13 @@ a,
       text-decoration: none;
     }
 
-    &:not(.-no-underline):not(.-cta) {
+    &:not(.-no-underline, .-cta, .chi-dropdown__menu-item) {
       @include link-icon-text-children {
         text-decoration: $link-text-decoration;
       }
     }
 
-    &:not(.-no-hover-underline):not(.-cta) {
+    &:not(.-no-hover-underline, .-cta, .chi-dropdown__menu-item) {
       &:hover,
       &.-hover {
         @include link-icon-text-children {


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7207

This pull request makes a small update to the link styling in `link.scss` to ensure that dropdown menu items are excluded from certain underline styles. This helps maintain consistent styling for links within dropdown menus.

* Updated the CSS selectors in `link.scss` so that elements with the `.-cta` or `.chi-dropdown__menu-item` classes are excluded from receiving underline styles and hover underline effects.