### PR TITLE
[DPEDE-7259] Improve responsive behaviour in agentic experience

### DIFF
--- a/src/chi/agentic/_variables.scss
+++ b/src/chi/agentic/_variables.scss
@@ -72,6 +72,10 @@ $agentic-button-transition:
 
 //#region Drawer
 $agentic-drawer-border: 0.0625rem solid $agentic-color-grey-60;
+$agentic-drawer-box-shadow: -0.5rem 0 1rem rgba(0, 0, 0, 0.2);
+$agentic-drawer-width: 31.25rem;
+$agentic-drawer-width-xxl: 35rem;
+$agentic-drawer-width-md: 27.5rem;
 //#endregion
 
 //#region Composer textarea

--- a/src/chi/agentic/components/drawer.scss
+++ b/src/chi/agentic/components/drawer.scss
@@ -2,6 +2,38 @@
   &.-agentic {
     border: $agentic-drawer-border;
 
+    &.-right {
+      box-shadow: none;
+      width: $agentic-drawer-width;
+
+      &.-animated:not(.-active) {
+        transform: translateX(100%);
+      }
+    }
+
+    @media only screen and (min-width: 1920px) {
+      &.-right {
+        width: $agentic-drawer-width-xxl;
+      }
+    }
+
+    @media only screen and (max-width: 1439px) {
+      border: 0;
+    }
+
+    @media only screen and (max-width: 1279px) {
+      &.-right {
+        width: $agentic-drawer-width-md;
+      }
+    }
+
+    @media only screen and (max-width: 743px) {
+      &.-right {
+        max-width: 100vw;
+        width: 100%;
+      }
+    }
+
     .agentic-drawer-title {
       display: flex;
       gap: 0.5rem;
@@ -40,10 +72,6 @@
     }
 
     @media only screen and (max-width: 767px) {
-      &.-right {
-        max-width: 85vw;
-      }
-
       .chi-drawer__header {
         padding: 1.5rem 1rem;
       }
@@ -54,6 +82,16 @@
 
       .chi-drawer__footer {
         padding: 1rem;
+      }
+    }
+  }
+}
+
+chi-drawer {
+  &[inline] {
+    &[position='right'] {
+      @media only screen and (max-width: 1439px) {
+        box-shadow: $agentic-drawer-box-shadow;
       }
     }
   }


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7259

This pull request updates the styling for the agentic drawer component, focusing on improved responsiveness and visual consistency across different screen sizes. Key changes include the introduction of new drawer sizing variables, enhanced responsive width adjustments, and improved box-shadow handling for right-positioned drawers.

**Drawer Styling and Responsiveness:**

* Added new SCSS variables for drawer box-shadow and multiple drawer widths (`$agentic-drawer-width`, `$agentic-drawer-width-xxl`, `$agentic-drawer-width-md`) to `src/chi/agentic/_variables.scss` for easier maintenance and customization.
* Updated `.drawer.-agentic.-right` styles in `src/chi/agentic/components/drawer.scss` to set default width, remove box-shadow, and add animated slide-in/out transitions.
* Implemented responsive width adjustments for `.drawer.-agentic.-right` at various breakpoints (≥1920px, ≤1279px, ≤743px) to ensure optimal drawer sizing on all devices.
* Removed the previous max-width restriction for right-positioned drawers on screens ≤767px, allowing for new responsive logic.

**Box Shadow Handling:**

* Added a media query for `chi-drawer[inline][position='right']` to apply a custom box-shadow on screens ≤1439px, enhancing visual separation when the drawer is inline.