### PR TITLE
[DPEDE-5698] Fix card accordion double border

### DIFF
--- a/src/chi/components/card/card.scss
+++ b/src/chi/components/card/card.scss
@@ -497,6 +497,10 @@
         }
 
         &.-expanded {
+          .chi-accordion__trigger {
+            border-bottom: $card-accordion-border;
+          }
+
           .chi-accordion__content {
             padding: $card-accordion-content-padding;
 

--- a/src/chi/components/card/card.scss
+++ b/src/chi/components/card/card.scss
@@ -488,6 +488,7 @@
       > chi-accordion .chi-accordion__item,
       > .chi-accordion .chi-accordion__item {
         background-color: transparent;
+        border: 0;
 
         .chi-accordion__trigger {
           background-color: transparent;
@@ -496,10 +497,6 @@
         }
 
         &.-expanded {
-          .chi-accordion__trigger {
-            border-bottom: $card-accordion-border;
-          }
-
           .chi-accordion__content {
             padding: $card-accordion-content-padding;
 
@@ -554,10 +551,13 @@
   }
 
   &.-accordion {
+    border: $card-accordion-border;
+
     > chi-accordion .chi-accordion,
     > .chi-accordion {
       .chi-accordion__item {
         background-color: transparent;
+        border: 0;
 
         .chi-accordion__trigger {
           background-color: transparent;
@@ -649,10 +649,6 @@
         border: none;
         padding: 0;
       }
-    }
-
-    &.-accordion {     
-      border: $card-accordion-border;
     }
   }
 }

--- a/src/chi/components/card/card.scss
+++ b/src/chi/components/card/card.scss
@@ -488,7 +488,7 @@
       > chi-accordion .chi-accordion__item,
       > .chi-accordion .chi-accordion__item {
         background-color: transparent;
-        border: 0;
+        border: none;
 
         .chi-accordion__trigger {
           background-color: transparent;
@@ -561,7 +561,7 @@
     > .chi-accordion {
       .chi-accordion__item {
         background-color: transparent;
-        border: 0;
+        border: none;
 
         .chi-accordion__trigger {
           background-color: transparent;

--- a/src/chi/components/card/card.scss
+++ b/src/chi/components/card/card.scss
@@ -554,8 +554,6 @@
   }
 
   &.-accordion {
-    border: $card-accordion-border;
-
     > chi-accordion .chi-accordion,
     > .chi-accordion {
       .chi-accordion__item {
@@ -651,6 +649,10 @@
         border: none;
         padding: 0;
       }
+    }
+
+    &.-accordion {     
+      border: $card-accordion-border;
     }
   }
 }

--- a/src/chi/templates/app-layout.scss
+++ b/src/chi/templates/app-layout.scss
@@ -326,7 +326,8 @@
       .chi-main__accordion {
         > chi-accordion > .chi-accordion > .chi-accordion__item {
           background: transparent;
-
+          border: 0;
+          
           > .chi-accordion__trigger,
           > .chi-accordion__content {
             padding: 0;

--- a/src/chi/themes/connect/_variables.scss
+++ b/src/chi/themes/connect/_variables.scss
@@ -997,7 +997,7 @@ $button-group-vertical-xl-padding: 0.875rem;
 
 // Card
 $card-accordion-border-width: 0.0625rem;
-$card-accordion-border: none;
+$card-accordion-border: $card-accordion-border-width solid rgba($color-black, 0.12);
 $card-accordion-card-content-padding: 0;
 $card-accordion-content-padding-bottom: 0.625rem;
 $card-accordion-content-padding-top: 0;

--- a/src/chi/themes/connect/_variables.scss
+++ b/src/chi/themes/connect/_variables.scss
@@ -997,7 +997,7 @@ $button-group-vertical-xl-padding: 0.875rem;
 
 // Card
 $card-accordion-border-width: 0.0625rem;
-$card-accordion-border: $card-accordion-border-width solid rgba($color-black, 0.12);
+$card-accordion-border: none;
 $card-accordion-card-content-padding: 0;
 $card-accordion-content-padding-bottom: 0.625rem;
 $card-accordion-content-padding-top: 0;


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-5698

This pull request updates the styling for accordion cards in the `chi` component library. The main change is to how borders are applied to accordion cards, moving the border definition from a global variable to a more specific selector, and setting the default border to `none` to avoid unintended borders elsewhere.

**Accordion Card Border Styling:**

* Changed the `$card-accordion-border` variable in `_variables.scss` to `none` to prevent global border application.
* Moved the border styling for accordion cards into a more specific `.chi-card.-accordion .-accordion` selector in `card.scss`, ensuring borders only appear where intended. [[1]](diffhunk://#diff-7f7ad473529eefd1e5285d6c0f9497629cff478c8687e5d681b0d9a0157ed64fL557-L558) [[2]](diffhunk://#diff-7f7ad473529eefd1e5285d6c0f9497629cff478c8687e5d681b0d9a0157ed64fR653-R656)