### PR TITLE
[DPEDE-7319] Enhance hidden columns styles in data table

### DIFF
--- a/src/chi/components/data-table/data-table.scss
+++ b/src/chi/components/data-table/data-table.scss
@@ -623,7 +623,9 @@ $sizes: (
     &.-hidden-column {
       flex-basis: 2rem;
       flex-grow: 0;
-      right: 3rem;
+      right: 1rem;
+      top: 50%;
+      transform: translateY(-50%);
       z-index: 1;
     }
   }


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7319

This pull request updates the `backstop-non-responsive-ce.json` configuration file to use the latest version (7.13.0) of the Chi UI library for all relevant test URLs. This ensures that visual regression tests are run against the most current version of the component library.

**Test configuration updates:**

* Updated all test URLs from `chi/7.12.0` to `chi/7.13.0` for custom elements and components, ensuring BackstopJS tests reference the latest Chi version. [[1]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L17-R17) [[2]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L42-R42) [[3]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L76-R76) [[4]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L112-R112) [[5]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L137-R137)
* Applied the version update consistently across a wide range of components including `accordion`, `alert-banner`, `alert-bubble`, `alert-toast`, `app-layout`, `brand`, `badges`, `icons`, `buttons`, `card`, `carousel`, `checkbox`, `copy-text`, `date-picker`, `drawer`, `dropdown`, `dropdown-select`, `expansion-panel`, `form-wrapper`, `popover`, `modals`, `progress`, `input-search`, `input-text`, `input-number`, `label`, `link`, `marketing-icon`, `pagination`, `picker`, `skeleton`, `spinner`, `tabs`, `tags`, `textarea`, and `toggle-switch`. [[1]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L163-R163) [[2]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L181-R181) [[3]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L206-R206) [[4]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L224-R224) [[5]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L269-R269) [[6]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L329-R329) [[7]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L355-R355) [[8]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L373-R373) [[9]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L391-R391) [[10]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L417-R417) [[11]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L473-R473) [[12]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L498-R498) [[13]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L516-R516) [[14]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L542-R549) [[15]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L596-R596) [[16]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L615-R615) [[17]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L644-R644) [[18]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L673-R673) [[19]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L732-R732) [[20]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L766-R766) [[21]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L789-R789) [[22]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L814-R814) [[23]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L839-R839) [[24]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L867-R867) [[25]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L921-R921) [[26]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L939-R939) [[27]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L973-R973) [[28]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L1000-R1000) [[29]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L1024-R1024) [[30]](diffhunk://#diff-33b06af0bbf93a053ecdb3fe0df53dc6b3f8801bf15cdf2c239bf1978c989356L1073-R1073)

This change is necessary to keep our visual regression tests aligned with the latest UI component updates and bug fixes. No other configuration or logic changes were made.