### PR TITLE
[DPEDE-7343] Fix drag accordion, card type, and sidenav borders

### DIFF
--- a/src/chi/components/card/card.scss
+++ b/src/chi/components/card/card.scss
@@ -499,6 +499,8 @@
         &.-expanded {
           .chi-accordion__trigger {
             border-bottom: $card-accordion-border;
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
           }
 
           .chi-accordion__content {

--- a/src/chi/components/drag-and-drop/drag-and-drop.scss
+++ b/src/chi/components/drag-and-drop/drag-and-drop.scss
@@ -195,7 +195,7 @@
       .chi-accordion {
         .chi-accordion__item {
           background-color: $drag-accordion-item-background-color;
-          border: 0;
+          border: none;
           
           .chi-accordion__trigger {
             padding: $drag-accordion-trigger-padding;

--- a/src/chi/components/drag-and-drop/drag-and-drop.scss
+++ b/src/chi/components/drag-and-drop/drag-and-drop.scss
@@ -195,7 +195,8 @@
       .chi-accordion {
         .chi-accordion__item {
           background-color: $drag-accordion-item-background-color;
-
+          border: 0;
+          
           .chi-accordion__trigger {
             padding: $drag-accordion-trigger-padding;
 

--- a/src/chi/components/sidebar/sidenav.scss
+++ b/src/chi/components/sidebar/sidenav.scss
@@ -209,7 +209,7 @@ $sidenav-lg-width: 12.5rem;
 
         .chi-accordion__item {
           background-color: transparent;
-          border-bottom: 0;
+          border: 0;
           margin-bottom: 0;
 
           .chi-accordion__content {

--- a/src/chi/components/sidebar/sidenav.scss
+++ b/src/chi/components/sidebar/sidenav.scss
@@ -209,7 +209,7 @@ $sidenav-lg-width: 12.5rem;
 
         .chi-accordion__item {
           background-color: transparent;
-          border: 0;
+          border: none;
           margin-bottom: 0;
 
           .chi-accordion__content {


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7343

This pull request updates the styling of accordion components across several parts of the application to improve visual consistency and border handling. The main changes focus on border radius and border properties for expanded and embedded accordion items.

Accordion styling improvements:

* In `card.scss`, when a card accordion is expanded, the bottom left and right border radii are now set to zero for a cleaner visual transition between the trigger and content.
* In `drag-and-drop.scss`, accordion items now have their border removed (set to `border: 0`) to better match the intended design within drag-and-drop contexts.
* In `sidenav.scss`, the border property for accordion items has been changed from only removing the bottom border (`border-bottom: 0`) to removing all borders (`border: 0`), ensuring a more uniform look in the sidebar navigation.