### PR TITLE
[DPEDE-7523] Prepare Chi repo for LumenTech-prod releases

### DIFF
--- a/cicd/jenkins/Jenkinsfile
+++ b/cicd/jenkins/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
     PROJECT_NAME = 'ux-chi'
     PROJECT_MAL = 'CHI'
     DOCKER_REPO = 'chi'
+    ASSETS_SERVER_ORG = 'LumenTech-Prod'
 
     // Branch variables
     PROD_BRANCH = 'master'
@@ -410,7 +411,7 @@ pipeline {
                     ${CLEAN_SCRIPT}
                 """, label: "Cleaning before pushing to AssetsServer")
 
-                jslGitHubCloneRepo('ux-chi-AssetsServer')
+                jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG)
 
                 env.CHECK = sh(script: """
                     chmod +x ${CHECK_FOLDER_SCRIPT}
@@ -687,7 +688,7 @@ def gitHubRelease() {
 
 // This function is called to create and open a pull request
 def createAndOpenPullRequest(def version) {
-  def org = jslGitGetRepoOwner()
+  def org = env.ASSETS_SERVER_ORG
   def commitMessage = "[FSTEAM-4189] This PR is for CHI ${version}"
   def description = "You can check staging in https://assets-dev.ctl.io/chi/staging"
   def branchName = "CHI_${version}"
@@ -712,7 +713,7 @@ def createAndOpenPullRequest(def version) {
       git push --set-upstream origin "${branchName}"
       """)
 
-  jslGitHubPRCreate(commitMessage, description, branchName, 'master', GITHUB_PUBLISH_TOKEN_CREDENTIALS, 'ux-chi-AssetsServer')
+  jslGitHubPRCreate(commitMessage, description, branchName, 'master', GITHUB_PUBLISH_TOKEN_CREDENTIALS, 'ux-chi-AssetsServer', org)
 }
 
 // This function is called to check/create the smoke tests


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7523

This pull request updates the Jenkins pipeline to support using a configurable GitHub organization for the `ux-chi-AssetsServer` repository, instead of relying on a hardcoded or inferred value. This improves flexibility and ensures all relevant steps use the correct organization.

**Jenkins pipeline updates for organization handling:**

* Added the `ASSETS_SERVER_ORG` variable (set to `'LumenTech-Prod'`) to the pipeline environment to specify the GitHub organization for `ux-chi-AssetsServer`.

* Updated the `jslGitHubCloneRepo` and `jslGitHubPRCreate` function calls to accept and use the `ASSETS_SERVER_ORG` variable, ensuring that all repository operations target the correct organization. [[1]](diffhunk://#diff-0493137fbaf2064a93e117d9aac7537bcb1cb1c301bda4e9ba215fca71804a6aL413-R414) [[2]](diffhunk://#diff-0493137fbaf2064a93e117d9aac7537bcb1cb1c301bda4e9ba215fca71804a6aL715-R716)

* Modified the `createAndOpenPullRequest` function to use `env.ASSETS_SERVER_ORG` instead of calling `jslGitGetRepoOwner()`, standardizing organization handling.