### PR TITLE
[DPEDE-7622] Fix AssetsServer releases

### DIFF
--- a/cicd/jenkins/Jenkinsfile
+++ b/cicd/jenkins/Jenkinsfile
@@ -36,6 +36,10 @@ pipeline {
     preserveStashes(buildCount: 10)
     disableConcurrentBuilds()
   }
+  // TEMP: remove after verifying the AssetsServer PR flow. Default is true so an opened PR runs ONLY the test stage.
+  parameters {
+    booleanParam(name: 'TEST_ASSETS_SERVER_PR', defaultValue: true, description: 'TEMPORARY: when true, only runs the AssetsServer PR test stage and skips the rest of the pipeline.')
+  }
   environment {
     // Project variables
     PROJECT_NAME = 'ux-chi'
@@ -103,6 +107,33 @@ pipeline {
     DEPLOY_AUTH_TOKEN = ''
   }
   stages {
+    // TEMP: isolated stage to test the AssetsServer PR flow only. Remove after verifying.
+    stage('Test AssetsServer PR only') {
+      when {
+        beforeAgent true
+        expression { return params.TEST_ASSETS_SERVER_PR != false }
+      }
+      agent {
+        docker {
+          image DOCKER_NODE22
+        }
+      }
+      steps {
+        script {
+          jslNpmWrapper('ci', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
+          jslNpmWrapper('run build:prod', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
+          jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
+          createAndOpenPullRequest('7.17')
+        }
+      }
+    }
+    // TEMP: wrapper so the whole normal pipeline is skipped while TEST_ASSETS_SERVER_PR is true. Remove after verifying.
+    stage('Full pipeline') {
+      when {
+        beforeAgent true
+        expression { return params.TEST_ASSETS_SERVER_PR == false }
+      }
+      stages {
     stage('Summary') {
       steps {
         script {
@@ -411,7 +442,7 @@ pipeline {
                     ${CLEAN_SCRIPT}
                 """, label: "Cleaning before pushing to AssetsServer")
 
-                jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG)
+                jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
 
                 env.CHECK = sh(script: """
                     chmod +x ${CHECK_FOLDER_SCRIPT}
@@ -515,6 +546,8 @@ pipeline {
           
           jslAdoptionMain('cypress/reports/*xml')
         }
+      }
+    }
       }
     }
   }

--- a/cicd/jenkins/Jenkinsfile
+++ b/cicd/jenkins/Jenkinsfile
@@ -120,8 +120,7 @@ pipeline {
       }
       steps {
         script {
-          // TEMP: hardcoded version for testing purposes instead of reading package.json.
-          def version = '7.18.0'
+          def packageJson = readJSON file: 'package.json'
 
           jslNpmWrapper('ci', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
           jslNpmWrapper('run build:prod', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
@@ -135,10 +134,10 @@ pipeline {
 
           env.CHECK = sh(script: """
               chmod +x ${CHECK_FOLDER_SCRIPT}
-              ${CHECK_FOLDER_SCRIPT} ${version}
+              ${CHECK_FOLDER_SCRIPT} ${packageJson.version}
           """, returnStdout: true).trim()
 
-          createAndOpenPullRequest(version)
+          createAndOpenPullRequest(packageJson.version)
         }
       }
     }

--- a/cicd/jenkins/Jenkinsfile
+++ b/cicd/jenkins/Jenkinsfile
@@ -120,10 +120,25 @@ pipeline {
       }
       steps {
         script {
+          // TEMP: hardcoded version for testing purposes instead of reading package.json.
+          def version = '7.18.0'
+
           jslNpmWrapper('ci', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
           jslNpmWrapper('run build:prod', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
-          jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
-          createAndOpenPullRequest('7.17')
+
+          sh(script: """
+              chmod +x ${CLEAN_SCRIPT}
+              ${CLEAN_SCRIPT}
+          """, label: "Cleaning before pushing to AssetsServer")
+
+          jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_ALTER_CREDENTIALS)
+
+          env.CHECK = sh(script: """
+              chmod +x ${CHECK_FOLDER_SCRIPT}
+              ${CHECK_FOLDER_SCRIPT} ${version}
+          """, returnStdout: true).trim()
+
+          createAndOpenPullRequest(version)
         }
       }
     }
@@ -442,7 +457,7 @@ pipeline {
                     ${CLEAN_SCRIPT}
                 """, label: "Cleaning before pushing to AssetsServer")
 
-                jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
+                jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_ALTER_CREDENTIALS)
 
                 env.CHECK = sh(script: """
                     chmod +x ${CHECK_FOLDER_SCRIPT}
@@ -746,7 +761,7 @@ def createAndOpenPullRequest(def version) {
       git push --set-upstream origin "${branchName}"
       """)
 
-  jslGitHubPRCreate(commitMessage, description, branchName, 'master', GITHUB_PUBLISH_TOKEN_CREDENTIALS, 'ux-chi-AssetsServer', org)
+  jslGitHubPRCreate(commitMessage, description, branchName, 'master', GITHUB_ALTER_CREDENTIALS, 'ux-chi-AssetsServer', org)
 }
 
 // This function is called to check/create the smoke tests

--- a/cicd/jenkins/Jenkinsfile
+++ b/cicd/jenkins/Jenkinsfile
@@ -36,9 +36,6 @@ pipeline {
     preserveStashes(buildCount: 10)
     disableConcurrentBuilds()
   }
-  parameters {
-    booleanParam(name: 'TEST_ASSETS_SERVER_PR', defaultValue: true, description: 'TEMPORARY: when true, only runs the AssetsServer PR test stage and skips the rest of the pipeline.')
-  }
   environment {
     // Project variables
     PROJECT_NAME = 'ux-chi'
@@ -107,46 +104,6 @@ pipeline {
     DEPLOY_AUTH_TOKEN = ''
   }
   stages {
-    stage('Test AssetsServer PR only') {
-      when {
-        beforeAgent true
-        expression { return params.TEST_ASSETS_SERVER_PR != false }
-      }
-      agent {
-        docker {
-          image DOCKER_NODE22
-        }
-      }
-      steps {
-        script {
-          def version = '7.19.0'
-
-          jslNpmWrapper('ci', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
-          jslNpmWrapper('run build:prod', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
-
-          sh(script: """
-              chmod +x ${CLEAN_SCRIPT}
-              ${CLEAN_SCRIPT}
-          """, label: "Cleaning before pushing to AssetsServer")
-
-          jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_APP_CREDENTIALS)
-
-          env.CHECK = sh(script: """
-              chmod +x ${CHECK_FOLDER_SCRIPT}
-              ${CHECK_FOLDER_SCRIPT} ${version}
-          """, returnStdout: true).trim()
-
-          createAndOpenPullRequest(version)
-        }
-      }
-    }
-    // TEMP: wrapper so the whole normal pipeline is skipped while TEST_ASSETS_SERVER_PR is true. Remove after verifying.
-    stage('Full pipeline') {
-      when {
-        beforeAgent true
-        expression { return params.TEST_ASSETS_SERVER_PR == false }
-      }
-      stages {
     stage('Summary') {
       steps {
         script {
@@ -559,8 +516,6 @@ pipeline {
           
           jslAdoptionMain('cypress/reports/*xml')
         }
-      }
-    }
       }
     }
   }

--- a/cicd/jenkins/Jenkinsfile
+++ b/cicd/jenkins/Jenkinsfile
@@ -36,10 +36,6 @@ pipeline {
     preserveStashes(buildCount: 10)
     disableConcurrentBuilds()
   }
-  // TEMP: remove after verifying the AssetsServer PR flow. Default is true so an opened PR runs ONLY the test stage.
-  parameters {
-    booleanParam(name: 'TEST_ASSETS_SERVER_PR', defaultValue: true, description: 'TEMPORARY: when true, only runs the AssetsServer PR test stage and skips the rest of the pipeline.')
-  }
   environment {
     // Project variables
     PROJECT_NAME = 'ux-chi'
@@ -107,47 +103,6 @@ pipeline {
     DEPLOY_AUTH_TOKEN = ''
   }
   stages {
-    // TEMP: isolated stage to test the AssetsServer PR flow only. Remove after verifying.
-    stage('Test AssetsServer PR only') {
-      when {
-        beforeAgent true
-        expression { return params.TEST_ASSETS_SERVER_PR != false }
-      }
-      agent {
-        docker {
-          image DOCKER_NODE22
-        }
-      }
-      steps {
-        script {
-          def packageJson = readJSON file: 'package.json'
-
-          jslNpmWrapper('ci', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
-          jslNpmWrapper('run build:prod', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
-
-          sh(script: """
-              chmod +x ${CLEAN_SCRIPT}
-              ${CLEAN_SCRIPT}
-          """, label: "Cleaning before pushing to AssetsServer")
-
-          jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_ALTER_CREDENTIALS)
-
-          env.CHECK = sh(script: """
-              chmod +x ${CHECK_FOLDER_SCRIPT}
-              ${CHECK_FOLDER_SCRIPT} ${packageJson.version}
-          """, returnStdout: true).trim()
-
-          createAndOpenPullRequest(packageJson.version)
-        }
-      }
-    }
-    // TEMP: wrapper so the whole normal pipeline is skipped while TEST_ASSETS_SERVER_PR is true. Remove after verifying.
-    stage('Full pipeline') {
-      when {
-        beforeAgent true
-        expression { return params.TEST_ASSETS_SERVER_PR == false }
-      }
-      stages {
     stage('Summary') {
       steps {
         script {
@@ -560,8 +515,6 @@ pipeline {
           
           jslAdoptionMain('cypress/reports/*xml')
         }
-      }
-    }
       }
     }
   }

--- a/cicd/jenkins/Jenkinsfile
+++ b/cicd/jenkins/Jenkinsfile
@@ -36,6 +36,9 @@ pipeline {
     preserveStashes(buildCount: 10)
     disableConcurrentBuilds()
   }
+  parameters {
+    booleanParam(name: 'TEST_ASSETS_SERVER_PR', defaultValue: true, description: 'TEMPORARY: when true, only runs the AssetsServer PR test stage and skips the rest of the pipeline.')
+  }
   environment {
     // Project variables
     PROJECT_NAME = 'ux-chi'
@@ -53,6 +56,7 @@ pipeline {
     GITHUB_TOKEN_CREDENTIALS = 'GITHUB_APP_CREDENTIALS'
     GITHUB_SSH_CREDENTIALS = 'SCMAUTO_SSH_DEVOPS_PIPELINE'
     GITHUB_ALTER_CREDENTIALS = 'JCTOKEN'
+    GITHUB_APP_CREDENTIALS = 'gh-app-credentials'
     GITHUB_PUBLISH_TOKEN_CREDENTIALS = 'allyourbotsarebelongtous-token'
     
     // Docker variables
@@ -103,6 +107,46 @@ pipeline {
     DEPLOY_AUTH_TOKEN = ''
   }
   stages {
+    stage('Test AssetsServer PR only') {
+      when {
+        beforeAgent true
+        expression { return params.TEST_ASSETS_SERVER_PR != false }
+      }
+      agent {
+        docker {
+          image DOCKER_NODE22
+        }
+      }
+      steps {
+        script {
+          def version = '7.19.0'
+
+          jslNpmWrapper('ci', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
+          jslNpmWrapper('run build:prod', GITHUB_PUBLISH_TOKEN_CREDENTIALS)
+
+          sh(script: """
+              chmod +x ${CLEAN_SCRIPT}
+              ${CLEAN_SCRIPT}
+          """, label: "Cleaning before pushing to AssetsServer")
+
+          jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_APP_CREDENTIALS)
+
+          env.CHECK = sh(script: """
+              chmod +x ${CHECK_FOLDER_SCRIPT}
+              ${CHECK_FOLDER_SCRIPT} ${version}
+          """, returnStdout: true).trim()
+
+          createAndOpenPullRequest(version)
+        }
+      }
+    }
+    // TEMP: wrapper so the whole normal pipeline is skipped while TEST_ASSETS_SERVER_PR is true. Remove after verifying.
+    stage('Full pipeline') {
+      when {
+        beforeAgent true
+        expression { return params.TEST_ASSETS_SERVER_PR == false }
+      }
+      stages {
     stage('Summary') {
       steps {
         script {
@@ -411,7 +455,7 @@ pipeline {
                     ${CLEAN_SCRIPT}
                 """, label: "Cleaning before pushing to AssetsServer")
 
-                jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_ALTER_CREDENTIALS)
+                jslGitHubCloneRepo('ux-chi-AssetsServer', env.ASSETS_SERVER_ORG, 'master', GITHUB_APP_CREDENTIALS)
 
                 env.CHECK = sh(script: """
                     chmod +x ${CHECK_FOLDER_SCRIPT}
@@ -515,6 +559,8 @@ pipeline {
           
           jslAdoptionMain('cypress/reports/*xml')
         }
+      }
+    }
       }
     }
   }
@@ -713,7 +759,7 @@ def createAndOpenPullRequest(def version) {
       git push --set-upstream origin "${branchName}"
       """)
 
-  jslGitHubPRCreate(commitMessage, description, branchName, 'master', GITHUB_ALTER_CREDENTIALS, 'ux-chi-AssetsServer', org)
+  jslGitHubPRCreate(commitMessage, description, branchName, 'master', GITHUB_APP_CREDENTIALS, 'ux-chi-AssetsServer', org)
 }
 
 // This function is called to check/create the smoke tests


### PR DESCRIPTION
https://lumen.atlassian.net/browse/DPEDE-7622

This pull request introduces a temporary modification to the Jenkins pipeline to isolate and test the AssetsServer pull request (PR) flow. The changes add a parameter to control pipeline execution, a dedicated test stage for the AssetsServer PR, and update repository cloning commands to ensure proper authentication. The normal pipeline is conditionally skipped while the test is active. These changes are intended to be removed after verification.

Pipeline control and AssetsServer PR testing:

* Added a temporary `TEST_ASSETS_SERVER_PR` boolean parameter to enable running only the AssetsServer PR test stage, skipping the rest of the pipeline (`cicd/jenkins/Jenkinsfile`).
* Introduced a new `Test AssetsServer PR only` stage that runs when `TEST_ASSETS_SERVER_PR` is true, performing build, test, and PR creation steps for the AssetsServer (`cicd/jenkins/Jenkinsfile`).
* Wrapped the normal pipeline in a `Full pipeline` stage that only runs when `TEST_ASSETS_SERVER_PR` is false, ensuring mutual exclusivity between test and normal flows (`cicd/jenkins/Jenkinsfile`). [[1]](diffhunk://#diff-0493137fbaf2064a93e117d9aac7537bcb1cb1c301bda4e9ba215fca71804a6aR109-R135) [[2]](diffhunk://#diff-0493137fbaf2064a93e117d9aac7537bcb1cb1c301bda4e9ba215fca71804a6aR552-R553)

Repository cloning and authentication:

* Updated calls to `jslGitHubCloneRepo` to explicitly pass the branch (`'master'`) and credentials (`GITHUB_PUBLISH_TOKEN_CREDENTIALS`) for secure and consistent repository access (`cicd/jenkins/Jenkinsfile`).